### PR TITLE
Feature: Add submissions filter by attribute value

### DIFF
--- a/controllers/classes_controller.rb
+++ b/controllers/classes_controller.rb
@@ -9,7 +9,7 @@ class ClassesController < ApplicationController
       cls_count = submission.class_count(LOGGER)
       error 403, "Unable to display classes due to missing metrics for #{submission.id.to_s}. Please contact the administrator." if cls_count < 0
 
-      attributes, page, size, filter_by_label, order_by_hash, bring_unmapped_needed  =  settings_params(LinkedData::Models::Class)
+      attributes, page, size, order_by_hash, bring_unmapped_needed  =  settings_params(LinkedData::Models::Class)
       check_last_modified_segment(LinkedData::Models::Class, [ont.acronym])
 
       index = LinkedData::Models::Class.in(submission)

--- a/controllers/collection_controller.rb
+++ b/controllers/collection_controller.rb
@@ -30,7 +30,7 @@ class CollectionsController < ApplicationController
 
       get '/members' do
         ont, submission = get_ontology_and_submission
-        attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Class)
+        attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Class)
         collection_uri = get_collection_uri(params)
         data = LinkedData::Models::Class.where(memberOf: collection_uri).in(submission).include(attributes).page(page,size).all
         reply data

--- a/controllers/instances_controller.rb
+++ b/controllers/instances_controller.rb
@@ -7,8 +7,8 @@ class InstancesController < ApplicationController
     check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
     cls = get_class(sub)
     error 404 if cls.nil?
-
-    attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
+    filter_by_label = label_regex_filter
+    attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
 
 
 
@@ -20,7 +20,7 @@ class InstancesController < ApplicationController
     page_data.order_by(order_by) unless order_by.nil?
     page_data = page_data.page(page,size).all
 
-    bring_unmapped_to page_data , sub if bring_unmapped_needed
+    bring_unmapped_to page_data , sub, LinkedData::Models::Instance if bring_unmapped_needed
 
     reply page_data
   end
@@ -30,8 +30,8 @@ class InstancesController < ApplicationController
     get do
       ont, sub = get_ontology_and_submission
       check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
-
-      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
+      filter_by_label = label_regex_filter
+      attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
 
 
       page_data = LinkedData::Models::Instance.where
@@ -42,7 +42,7 @@ class InstancesController < ApplicationController
       page_data.order_by(order_by) unless order_by.nil?
       page_data = page_data.page(page,size).all
 
-      bring_unmapped_to page_data , sub if bring_unmapped_needed
+      bring_unmapped_to page_data , sub, LinkedData::Models::Instance if bring_unmapped_needed
 
       reply page_data
     end
@@ -51,11 +51,11 @@ class InstancesController < ApplicationController
       ont, sub = get_ontology_and_submission
       check_last_modified_segment(LinkedData::Models::Instance, [ont.acronym])
 
-      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
+      attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::Instance)
 
       page_data = LinkedData::Models::Instance.find(@params["inst"]).include(attributes).in(sub).first
 
-      bring_unmapped_to [page_data] , sub if bring_unmapped_needed
+      bring_unmapped_to [page_data] , sub, LinkedData::Models::Instance if bring_unmapped_needed
 
       reply page_data
     end

--- a/controllers/skos_xl_label_controller.rb
+++ b/controllers/skos_xl_label_controller.rb
@@ -3,7 +3,7 @@ class SkosXlLabelController < ApplicationController
   namespace "/ontologies/:ontology/skos_xl_labels" do
     get  do
       ont, submission = get_ontology_and_submission
-      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Label)
+      attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Label)
       labels = LinkedData::Models::SKOS::Label.where.in(submission).include(attributes).page(page, size).all
       if labels && bring_unmapped_needed
         LinkedData::Models::SKOS::Label.in(submission).models(labels).include(:unmapped).all
@@ -13,7 +13,7 @@ class SkosXlLabelController < ApplicationController
 
     get '/:id' do
       ont, submission = get_ontology_and_submission
-      attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Label)
+      attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Label)
       label = LinkedData::Models::SKOS::Label.find(params[:id]).in(submission).include(attributes).first
       if label && bring_unmapped_needed
         LinkedData::Models::SKOS::Label.in(submission).models([label]).include(:unmapped).all

--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -370,15 +370,14 @@ module Sinatra
         end
 
         submissions_query = submissions_query.filter(Goo::Filter.new(ontology: [:viewOf]).unbound) unless include_views
+        submissions_query = submissions_query.filter(filter) if filter?
         # When asking to display all metadata, we are using bring_remaining on each submission. Slower but best way to retrieve all attrs
         if includes_param.first == :all
-          including = [:submissionId, {:contact=>[:name, :email], :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl,
+          includes = [:submissionId, {:contact=>[:name, :email], :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl,
                                        :group, :hasDomain, :views, :viewOf, :flat], :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus]
-          submissions = submissions_query.include(including).to_a
-        else
-          submissions = submissions_query.include(includes).to_a
         end
-
+        submissions = submissions_query.include(includes).to_a
+        
         # Figure out latest parsed submissions using all submissions
         latest_submissions = {}
         submissions.each do |sub|
@@ -391,7 +390,7 @@ module Sinatra
           latest_submissions[sub.ontology.acronym] ||= sub
           latest_submissions[sub.ontology.acronym] = sub if sub.submissionId.to_i > latest_submissions[sub.ontology.acronym].submissionId.to_i
         end
-        return latest_submissions
+        latest_submissions
       end
 
       def get_ontology_and_submission

--- a/helpers/collections_helper.rb
+++ b/helpers/collections_helper.rb
@@ -5,7 +5,7 @@ module Sinatra
     module CollectionsHelper
       def collections_setting_params
         ont, submission = get_ontology_and_submission
-        attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Collection)
+        attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Collection)
         [submission, attributes, bring_unmapped_needed]
       end
 

--- a/helpers/instances_helper.rb
+++ b/helpers/instances_helper.rb
@@ -3,58 +3,12 @@ require 'sinatra/base'
 module Sinatra
   module Helpers
     module InstancesHelper
-
-      # TODO: generalize this to all routes (maybe in application_helper)
-      def settings_params(klass)
-        page, size = page_params
-        attributes = get_attributes_to_include(includes_param, klass)
-        order_by = get_order_by_from(@params)
-        bring_unmapped = bring_unmapped?(includes_param)
-        filter_by_label = label_regex_filter
-
-        [attributes, page, size, filter_by_label, order_by, bring_unmapped]
-      end
-
-      def is_set?(param)
-        !param.nil? && param != ""
-      end
-
       def label_regex_filter
         (Goo::Filter.new(:label).regex(@params["search"])) if is_set?(@params["search"])
       end
 
       def filter_classes_by(class_uri)
-        class_uri.nil? ? nil :{types: RDF::URI.new(class_uri.to_s)}
-      end
-
-      def get_order_by_from(params, default_order = :asc)
-        if is_set?(params['sortby'])
-          orders = (params["order"] || default_order.to_s).split(',')
-          out = params['sortby'].split(',').map.with_index  do |param, index|
-            sort_order_item(param, orders[index] || default_order)
-          end
-          out.to_h
-        end
-
-      end
-
-      def get_attributes_to_include(includes_param, klass)
-        ld = klass.goo_attrs_to_load(includes_param)
-        ld.delete(:properties)
-        ld
-      end
-
-      def bring_unmapped?(includes_param)
-        (includes_param && includes_param.include?(:all))
-      end
-
-      def bring_unmapped_to(page_data, sub, klass = LinkedData::Models::Instance)
-        klass.in(sub).models(page_data).include(:unmapped).all
-      end
-
-      private
-      def sort_order_item(param , order)
-        [param.to_sym, order.to_sym]
+        class_uri.nil? ? nil : { types: RDF::URI.new(class_uri.to_s) }
       end
     end
   end

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -1,0 +1,56 @@
+require 'sinatra/base'
+
+module Sinatra
+  module Helpers
+    module RequestParamsHelper
+
+      def settings_params(klass)
+        page, size = page_params
+        attributes = get_attributes_to_include(includes_param, klass)
+        order_by = get_order_by_from(@params)
+        bring_unmapped = bring_unmapped?(includes_param, klass)
+
+        [attributes, page, size, order_by, bring_unmapped]
+      end
+
+      def is_set?(param)
+        !param.nil? && param != ""
+      end
+
+
+
+
+
+      def get_order_by_from(params, default_order = :asc)
+        if is_set?(params['sortby'])
+          orders = (params["order"] || default_order.to_s).split(',')
+          out = params['sortby'].split(',').map.with_index  do |param, index|
+            sort_order_item(param, orders[index] || default_order)
+          end
+          out.to_h
+        end
+      end
+
+      def get_attributes_to_include(includes_param, klass)
+        ld = klass.goo_attrs_to_load(includes_param)
+        ld.delete(:properties)
+        ld
+      end
+
+      def bring_unmapped?(includes_param)
+        (includes_param && includes_param.include?(:all))
+      end
+
+      def bring_unmapped_to(page_data, sub, klass)
+        klass.in(sub).models(page_data).include(:unmapped).all
+      end
+
+      private
+      def sort_order_item(param , order)
+        [param.to_sym, order.to_sym]
+      end
+    end
+  end
+end
+
+helpers Sinatra::Helpers::RequestParamsHelper

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -8,7 +8,7 @@ module Sinatra
         page, size = page_params
         attributes = get_attributes_to_include(includes_param, klass)
         order_by = get_order_by_from(@params)
-        bring_unmapped = bring_unmapped?(includes_param, klass)
+        bring_unmapped = bring_unmapped?(includes_param)
 
         [attributes, page, size, order_by, bring_unmapped]
       end

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -17,14 +17,18 @@ module Sinatra
         !param.nil? && param != ""
       end
 
+      def filter?
+        is_set?(@params["filter_by"])
+      end
 
-
-
+      def filter
+        build_filter
+      end
 
       def get_order_by_from(params, default_order = :asc)
         if is_set?(params['sortby'])
           orders = (params["order"] || default_order.to_s).split(',')
-          out = params['sortby'].split(',').map.with_index  do |param, index|
+          out = params['sortby'].split(',').map.with_index do |param, index|
             sort_order_item(param, orders[index] || default_order)
           end
           out.to_h
@@ -46,8 +50,13 @@ module Sinatra
       end
 
       private
-      def sort_order_item(param , order)
+
+      def sort_order_item(param, order)
         [param.to_sym, order.to_sym]
+      end
+
+      def build_filter(value = @params["filter_value"])
+        Goo::Filter.new(@params["filter_by"].to_sym).regex(value)
       end
     end
   end

--- a/helpers/schemes_helper.rb
+++ b/helpers/schemes_helper.rb
@@ -5,7 +5,7 @@ module Sinatra
     module SchemesHelper
       def schemes_setting_params
         ont, submission = get_ontology_and_submission
-        attributes, page, size, filter_by_label, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Scheme)
+        attributes, page, size, order_by, bring_unmapped_needed  =  settings_params(LinkedData::Models::SKOS::Scheme)
         [submission, attributes, bring_unmapped_needed]
       end
 


### PR DESCRIPTION
Based on https://github.com/ncbo/ontologies_api/pull/109, with this PR we can now do this `/submissions?display=includedInDataCatalog&filter_by=includedInDataCatalog&filter_value=vest.agrisemantics.org` and it will return only the submissions that are included in the vest.agrisemantics.org catalog

<img width="859" alt="image" src="https://user-images.githubusercontent.com/29259906/213482711-a03b6a72-76ec-407b-a33f-e5e776f6be6f.png">

