### PR TITLE
Feature: Add oder by and filters for ontologies endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: 1484ad56e39810208ee08a14d1319b6bc112f647
+  revision: c3456c45c12ed92d4a3ae43cac7c1d4cdbf290b6
   branch: development
   specs:
     goo (0.0.2)
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: f2168c8ad9ec447338da914d10a352df558494b5
+  revision: 4ac9873f3d016259196a17cfc9c6ab8149468ec9
   branch: development
   specs:
     ontologies_linked_data (0.0.1)
@@ -193,7 +193,7 @@ GEM
     json_pure (2.6.3)
     jwt (2.7.0)
     kgio (2.11.4)
-    libxml-ruby (4.0.0)
+    libxml-ruby (4.1.0)
     logger (1.5.3)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -228,7 +228,7 @@ GEM
       net-protocol
     net-ssh (7.1.0)
     netrc (0.11.0)
-    newrelic_rpm (9.2.0)
+    newrelic_rpm (9.2.1)
     oj (2.18.5)
     omni_logger (0.1.4)
       logger
@@ -344,7 +344,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 3.0)
@@ -398,4 +397,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.3.14
+   2.3.23

--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -47,7 +47,7 @@ class OntologiesController < ApplicationController
           latest.bring({:contact=>[:name, :email],
                       :ontology=>[:acronym, :name, :administeredBy, :group, :viewingRestriction, :doNotUpdate, :flat,
                                   :hasDomain, :summaryOnly, :acl, :viewOf, :ontologyType],
-                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]})
+                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym], :metrics =>[:classes, :individuals, :properties]})
         else
           latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param))
         end

--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -49,7 +49,11 @@ class OntologiesController < ApplicationController
                                   :hasDomain, :summaryOnly, :acl, :viewOf, :ontologyType],
                       :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym], :metrics =>[:classes, :individuals, :properties]})
         else
-          latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param))
+          includes = OntologySubmission.goo_attrs_to_load(includes_param)
+
+          includes << {:contact=>[:name, :email]} if includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:contact)}
+
+          latest.bring(*includes)
         end
       end
       #remove the whole previous if block and replace by it: latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param)) if latest

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -7,6 +7,8 @@ class OntologySubmissionsController < ApplicationController
     }
     subs = retrieve_latest_submissions(options)
     subs = subs.values unless page?
+    # Force to show ontology reviews, notes and projects by default only for this request
+    LinkedData::Models::Ontology.serialize_default(*(LinkedData::Models::Ontology.hypermedia_settings[:serialize_default] + [:reviews, :notes, :projects]))
     reply subs
   end
 

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -32,7 +32,7 @@ class OntologySubmissionsController < ApplicationController
         # When asking to display all metadata, we are using bring_remaining which is more performant than including all metadata (remove this when the query to get metadata will be fixed)
         ont.bring(submissions: [:released, :creationDate, :status, :submissionId,
                                 {:contact=>[:name, :email], :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl, :group, :hasDomain, :views, :viewOf, :flat],
-                                 :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus])
+                                 :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus], :metrics =>[:classes, :individuals, :properties])
 
         ont.submissions.each do |sub|
           sub.bring_remaining

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -51,6 +51,8 @@ module Sinatra
         query = add_inverse_filters(inverse_filters, query)
 
         query = add_acronym_name_filters(query)
+
+        add_order_by_patterns(query)
       end
 
 
@@ -124,6 +126,19 @@ module Sinatra
         elsif params[:name]
           filter = Goo::Filter.new(extract_attr(:ontology_name)).regex(params[:name])
           query = query.filter(filter)
+        end
+        query
+      end
+
+      def add_order_by_patterns(query)
+        if params[:order_by]
+          attr, sub_attr = params[:order_by].to_s.split('_')
+          if sub_attr
+            order_pattern = { attr.to_sym => { sub_attr.to_sym => (sub_attr.eql?("name") ? :asc : :desc) } }
+          else
+            order_pattern = { attr.to_sym => :desc }
+          end
+          query = query.order_by(order_pattern)
         end
         query
       end

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -49,6 +49,8 @@ module Sinatra
         query = add_direct_filters(filters, query)
 
         query = add_inverse_filters(inverse_filters, query)
+
+        query = add_acronym_name_filters(query)
       end
 
 

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -38,6 +38,7 @@ module Sinatra
           ontology_group_acronym: params[:group]&.split(','), #%w[RICE CROP],
           ontology_name: Array(params[:name]) + Array(params[:name]&.capitalize),
           isOfType: params[:isOfType]&.split(','), #["http://omv.ontoware.org/2005/05/ontology#Vocabulary"],
+          hasFormalityLevel: params[:hasFormalityLevel]&.split(','), #["http://w3id.org/nkos/nkostype#thesaurus"],
           ontology_viewingRestriction: params[:viewingRestriction]&.split(','), #["private"]
         }
         inverse_filters = {

--- a/helpers/request_params_helper.rb
+++ b/helpers/request_params_helper.rb
@@ -38,7 +38,7 @@ module Sinatra
           ontology_group_acronym: params[:group]&.split(','), #%w[RICE CROP],
           ontology_name: Array(params[:name]) + Array(params[:name]&.capitalize),
           isOfType: params[:isOfType]&.split(','), #["http://omv.ontoware.org/2005/05/ontology#Vocabulary"],
-          viewingRestriction: params[:viewingRestriction]&.split(','), #["private"]
+          ontology_viewingRestriction: params[:viewingRestriction]&.split(','), #["private"]
         }
         inverse_filters = {
           status: params[:status], #"retired",

--- a/helpers/submission_helper.rb
+++ b/helpers/submission_helper.rb
@@ -29,7 +29,8 @@ module Sinatra
           includes = [:submissionId, {:contact=>[:name, :email],
                                       :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl,
                                                                              :group, :hasDomain, :views, :viewOf, :flat, :notes, :reviews, :projects],
-                                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus]
+                                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym], :metrics =>[:classes, :individuals, :properties]},
+                      :submissionStatus]
         elsif includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:ontology)}
           includes << {:ontology=>[:administeredBy, :acronym, :name, :viewingRestriction, :group, :hasDomain,:notes, :reviews, :projects]}
         end

--- a/helpers/submission_helper.rb
+++ b/helpers/submission_helper.rb
@@ -26,10 +26,12 @@ module Sinatra
 
         # When asking to display all metadata, we are using bring_remaining on each submission. Slower but best way to retrieve all attrs
         if includes_param.first == :all
-          includes = [:submissionId, {:contact=>[:name, :email], :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl,
-                                                                             :group, :hasDomain, :views, :viewOf, :flat], :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus]
+          includes = [:submissionId, {:contact=>[:name, :email],
+                                      :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl,
+                                                                             :group, :hasDomain, :views, :viewOf, :flat, :notes, :reviews, :projects],
+                                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus]
         elsif includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:ontology)}
-          includes << {:ontology=>[:administeredBy, :acronym, :name, :viewingRestriction, :group, :hasDomain]}
+          includes << {:ontology=>[:administeredBy, :acronym, :name, :viewingRestriction, :group, :hasDomain,:notes, :reviews, :projects]}
         end
 
         submissions = submissions_query.include(includes)

--- a/helpers/submission_helper.rb
+++ b/helpers/submission_helper.rb
@@ -33,6 +33,8 @@ module Sinatra
                       :submissionStatus]
         elsif includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:ontology)}
           includes << {:ontology=>[:administeredBy, :acronym, :name, :viewingRestriction, :group, :hasDomain,:notes, :reviews, :projects]}
+        elsif includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:contact)}
+          includes << {:contact=>[:name, :email]}
         end
 
         submissions = submissions_query.include(includes)


### PR DESCRIPTION
### Follow up of 

- https://github.com/ontoportal-lirmm/ontologies_api/pull/34

### Prerequisites 

- https://github.com/ontoportal-lirmm/goo/pull/36
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/82

### Context
https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/217

### Changes

- Fix private-only submission filter(https://github.com/ontoportal-lirmm/ontologies_api/commit/1b7d514d949ce50bce74440082b83048b3a3aeec)
- Add hasFormalityLevel filter for submissions endpoint (https://github.com/ontoportal-lirmm/ontologies_api/commit/4cb42d0a333d5a57da6780e7a90fa8448f732cfc)
- Show for ontology: reviews, notes, and projects attributes in the submissions endpoints (https://github.com/ontoportal-lirmm/ontologies_api/commit/864e42fd8b8deffc6bc8c9e74765a1643026ee0a)
- Show metrics in the submissions endpoints (https://github.com/ontoportal-lirmm/ontologies_api/commit/04971936b6468897e41e42046aa8174a4a214a13)
- Show all contact attributes if asked in the submissions endpoints (https://github.com/ontoportal-lirmm/ontologies_api/commit/3abc4306a0ae0a26f46e00239552f884e3dc60f0) (fix of https://github.com/ontoportal-lirmm/ontologies_api/issues/22)
- Refactor submissions endpoint filters by extracting some methods (https://github.com/ontoportal-lirmm/ontologies_api/commit/69ef8bd9fb2fa268361d9f911a375e96db3c5671)
- Add ontology acronym or name filters for submissions endpoints (https://github.com/ontoportal-lirmm/ontologies_api/commit/1655473ab592af03ee34e64dd8c1af92fbb18a95)
- Add submissions endpoint order_by option (https://github.com/ontoportal-lirmm/ontologies_api/commit/d36446e154f4c55c69233779f8fb32438ecee414)
    Example: 
![image](https://user-images.githubusercontent.com/29259906/235503715-5b770648-0f42-4bf8-be35-32867ab508f8.png)

