### PR TITLE
Feature: Add multi provider authentication 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ tmp/*
 # Editor temp files
 *.swp
 *.swo
+test/solr

--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,5 @@ group :test do
   gem 'rack-test'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura' # for codecov.io
+  gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'ncbo_annotator', git: 'https://github.com/ontoportal-lirmm/ncbo_annotator.g
 gem 'ncbo_cron', git: 'https://github.com/ontoportal-lirmm/ncbo_cron.git', branch: 'master'
 gem 'ncbo_ontology_recommender', git: 'https://github.com/ncbo/ncbo_ontology_recommender.git', branch: 'master'
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'master'
-gem 'ontologies_linked_data', git: 'https://github.com/ontoportal-lirmm/ontologies_linked_data.git', branch: 'development'
+gem 'ontologies_linked_data', git: 'https://github.com/ontoportal-lirmm/ontologies_linked_data.git', branch: 'feature/add-multi-provider-authentification'
 
 group :development do
   # bcrypt_pbkdf and ed35519 is required for capistrano deployments when using ed25519 keys; see https://github.com/miloserdow/capistrano-deploy/issues/42

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,8 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: 4ac9873f3d016259196a17cfc9c6ab8149468ec9
-  branch: development
+  revision: 29c77d69da0c0566a450bc5f81ae6ce243e84b25
+  branch: feature/add-multi-provider-authentification
   specs:
     ontologies_linked_data (0.0.1)
       activesupport
@@ -103,7 +103,7 @@ GEM
     activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
@@ -249,7 +249,7 @@ GEM
       rack (>= 0.4)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
-    rack-mini-profiler (3.1.0)
+    rack-mini-profiler (3.1.1)
       rack (>= 1.2.0)
     rack-protection (1.5.5)
       rack
@@ -343,6 +343,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: f398b405f588d1161bc4e4893f5741360eb576f2
+  revision: e4b3a6d9bf575c1420924d4dbe1490248040aff7
   branch: feature/add-multi-provider-authentification
   specs:
     ontologies_linked_data (0.0.1)
@@ -126,6 +126,8 @@ GEM
       sshkit (~> 1.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
     cube-ruby (0.0.3)
     dante (0.2.0)
     date (3.3.3)
@@ -181,6 +183,7 @@ GEM
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
+    hashdiff (1.0.1)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -245,7 +248,7 @@ GEM
       rack (>= 0.4)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
-    rack-cache (1.14.0)
+    rack-cache (1.13.0)
       rack (>= 0.4)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
@@ -340,6 +343,10 @@ GEM
       unicorn (>= 4, < 7)
     uuid (2.3.9)
       macaddr (~> 1.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -396,6 +403,7 @@ DEPENDENCIES
   sparql-client!
   unicorn
   unicorn-worker-killer
+  webmock
 
 BUNDLED WITH
    2.3.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ncbo/ncbo_ontology_recommender.git
-  revision: d0ac992c88bd417f2f2137ba62934c3c41b6db7c
+  revision: 83e835de368bc9f19da800a477982e0ad770900d
   branch: master
   specs:
     ncbo_ontology_recommender (0.0.1)
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: c3456c45c12ed92d4a3ae43cac7c1d4cdbf290b6
+  revision: 1d78bde5a711d05475da0459308c7db074af5e21
   branch: development
   specs:
     goo (0.0.2)
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: 29c77d69da0c0566a450bc5f81ae6ce243e84b25
+  revision: f398b405f588d1161bc4e4893f5741360eb576f2
   branch: feature/add-multi-provider-authentification
   specs:
     ontologies_linked_data (0.0.1)
@@ -108,11 +108,11 @@ GEM
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
     backports (3.24.1)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     bcrypt_pbkdf (1.1.0)
     bigdecimal (1.4.2)
     builder (3.2.4)
-    capistrano (3.17.2)
+    capistrano (3.17.3)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -162,7 +162,7 @@ GEM
       ffi (~> 1.0)
     google-apis-analytics_v3 (0.13.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-core (0.11.0)
+    google-apis-core (0.11.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -171,7 +171,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    googleauth (1.5.2)
+    googleauth (1.7.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -191,9 +191,9 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     json_pure (2.6.3)
-    jwt (2.7.0)
+    jwt (2.7.1)
     kgio (2.11.4)
-    libxml-ruby (4.1.0)
+    libxml-ruby (4.1.1)
     logger (1.5.3)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -215,7 +215,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.3.0)
     net-http-persistent (2.9.4)
-    net-imap (0.3.4)
+    net-imap (0.3.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -226,9 +226,9 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.3.3)
       net-protocol
-    net-ssh (7.1.0)
+    net-ssh (7.2.0)
     netrc (0.11.0)
-    newrelic_rpm (9.2.2)
+    newrelic_rpm (9.3.1)
     oj (2.18.5)
     omni_logger (0.1.4)
       logger
@@ -239,13 +239,13 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     rack (1.6.13)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
-    rack-cache (1.13.0)
+    rack-cache (1.14.0)
       rack (>= 0.4)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
@@ -282,7 +282,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -318,13 +318,13 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    sshkit (1.21.4)
+    sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     systemu (2.6.5)
-    temple (0.10.0)
-    tilt (2.1.0)
-    timeout (0.3.2)
+    temple (0.10.2)
+    tilt (2.2.0)
+    timeout (0.4.0)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,6 +55,24 @@ LinkedData.config do |config|
       "apikey" => "1cfae05f-9e67-486f-820b-b393dec5764b"
     }
   }
+  config.oauth_providers = {
+    github: {
+      check: :access_token,
+      link: 'https://api.github.com/user'
+    },
+    keycloak: {
+      check: :jwt_token,
+      cert: 'KEYCLOAK_SECRET_KEY'
+    },
+    orcid: {
+      check: :access_token,
+      link: 'https://pub.orcid.org/v3.0/me'
+    },
+    google: {
+      check: :access_token,
+      link: 'https://www.googleapis.com/oauth2/v3/userinfo'
+    }
+  }
 end
 
 Annotator.config do |config|

--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -101,14 +101,7 @@ class UsersController < ApplicationController
       error 409, "User with username `#{params["username"]}` already exists" unless user.nil?
       user = instance_from_params(User, params)
       if user.valid?
-        user.save
-        # Send an email to the administrator to warn him about the newly created user
-        begin
-          if !LinkedData.settings.admin_emails.nil? && !LinkedData.settings.admin_emails.empty?
-            LinkedData::Utils::Notifications.new_user(user)
-          end
-        rescue Exception => e
-        end
+        user.save(send_notifications: false)
       else
         error 422, user.errors
       end

--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -1,14 +1,17 @@
 class UsersController < ApplicationController
   namespace "/users" do
     post "/authenticate" do
-      user_id       = params["user"]
-      user_password = params["password"]
+
       # Modify params to show all user attributes
       params["display"] = User.attributes.join(",")
-      user = User.find(user_id).include(User.goo_attrs_to_load(includes_param) + [:passwordHash]).first
-      authenticated = user.authenticate(user_password) unless user.nil?
-      error 401, "Username/password combination invalid" unless authenticated
-      user.show_apikey = true
+
+      if params["access_token"]
+        user = oauth_authenticate(params)
+      else
+        user = login_password_authenticate(params)
+      end
+      user.bring_remaining
+      user.show_apikey = true unless user.nil?
       reply user
     end
 

--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -7,10 +7,10 @@ class UsersController < ApplicationController
 
       if params["access_token"]
         user = oauth_authenticate(params)
+        user.bring(*User.goo_attrs_to_load(includes_param))
       else
         user = login_password_authenticate(params)
       end
-      user.bring_remaining
       user.show_apikey = true unless user.nil?
       reply user
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,10 +75,14 @@ services:
 
   redis-ut:
     image: redis
+    ports:
+      - 6379:6379
 
   4store-ut:
     image: bde2020/4store
     #volume: fourstore:/var/lib/4store
+    ports:
+      - 9000:9000
     command: >
       bash -c "4s-backend-setup --segments 4 ontoportal_kb
       && 4s-backend ontoportal_kb
@@ -88,10 +92,20 @@ services:
 
 
   solr-ut:
-    image: ontoportal/solr-ut:0.1
+    image: solr:8
+    volumes:
+      - ./test/solr/configsets:/configsets:ro
+    ports:
+      - "8983:8983"
+    command: >
+      bash -c "precreate-core term_search_core1 /configsets/term_search
+      && precreate-core prop_search_core1 /configsets/property_search
+      && solr-foreground"
 
   mgrep-ut:
     image: ontoportal/mgrep-ncbo:0.1
+    ports:
+      - "55556:55555"
 
   agraph-ut:
     image: franzinc/agraph:v7.3.0

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -345,6 +345,7 @@ module Sinatra
           doc[:submission] = old_class.submission
           doc[:properties] = MultiJson.load(doc.delete(:propertyRaw)) if include_param_contains?(:properties)
           instance = LinkedData::Models::Class.read_only(doc)
+          instance.prefLabel =  instance.prefLabel.first if instance.prefLabel.is_a?(Array)
           classes_hash[ont_uri_class_uri] = instance
         end
 

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -52,7 +52,7 @@ module Sinatra
         access_token  = params["access_token"]
         provider  = params["token_provider"]
         user = LinkedData::Models::User.oauth_authenticate(access_token, provider)
-        error 401, "Access token invalid" unless user.nil?
+        error 401, "Access token invalid"if user.nil?
         user
       end
 

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -48,6 +48,24 @@ module Sinatra
         [user, token.eql?(user.resetToken)]
       end
 
+      def oauth_authenticate(params)
+        access_token  = params["access_token"]
+        provider  = params["token_provider"]
+        user = LinkedData::Models::User.oauth_authenticate(access_token, provider)
+        error 401, "Access token invalid" unless user.nil?
+        user
+      end
+
+      def login_password_authenticate(params)
+        user_id       = params["user"]
+        user_password = params["password"]
+        user = User.find(user_id).include(User.goo_attrs_to_load(includes_param) + [:passwordHash]).first
+        authenticated = false
+        authenticated = user.authenticate(user_password) unless user.nil?
+        error 401, "Username/password combination invalid" unless authenticated
+
+        user
+      end
     end
   end
 end

--- a/test/controllers/test_ontologies_controller.rb
+++ b/test/controllers/test_ontologies_controller.rb
@@ -217,13 +217,13 @@ class TestOntologiesController < TestCase
     begin
       allowed_user = User.new({
         username: "allowed",
-        email: "test@example.org",
+        email: "test1@example.org",
         password: "12345"
       })
       allowed_user.save
       blocked_user = User.new({
         username: "blocked",
-        email: "test@example.org",
+        email: "test2@example.org",
         password: "12345"
       })
       blocked_user.save

--- a/test/controllers/test_ontology_submissions_controller.rb
+++ b/test/controllers/test_ontology_submissions_controller.rb
@@ -18,7 +18,7 @@ class TestOntologySubmissionsController < TestCase
       administeredBy: "tim",
       "file" => Rack::Test::UploadedFile.new(@@test_file, ""),
       released: DateTime.now.to_s,
-      contact: [{name: "test_name", email: "test@example.org"}],
+      contact: [{name: "test_name", email: "test3@example.org"}],
       URI: 'https://test.com/test',
       status: 'production',
       description: 'ontology description'
@@ -159,13 +159,13 @@ class TestOntologySubmissionsController < TestCase
     begin
       allowed_user = User.new({
         username: "allowed",
-        email: "test@example.org",
+        email: "test4@example.org",
         password: "12345"
       })
       allowed_user.save
       blocked_user = User.new({
         username: "blocked",
-        email: "test@example.org",
+        email: "test5@example.org",
         password: "12345"
       })
       blocked_user.save

--- a/test/controllers/test_search_controller.rb
+++ b/test/controllers/test_search_controller.rb
@@ -85,7 +85,7 @@ class TestSearchController < TestCase
     assert last_response.ok?
     results = MultiJson.load(last_response.body)
     doc = results["collection"][0]
-    assert_equal "cell line", doc["prefLabel"]
+    assert_equal "cell line", doc["prefLabel"].first
     assert doc["links"]["ontology"].include? acronym
     results["collection"].each do |doc|
       acr = doc["links"]["ontology"].split('/')[-1]
@@ -103,7 +103,8 @@ class TestSearchController < TestCase
     get "search?q=data&require_definitions=true"
     assert last_response.ok?
     results = MultiJson.load(last_response.body)
-    assert_equal 26, results["collection"].length
+    assert results["collection"].all? {|doc| !doc["definition"].nil? && doc.values.flatten.join(" ").include?("data") }
+    #assert_equal 26, results["collection"].length
 
     get "search?q=data&require_definitions=false"
     assert last_response.ok?
@@ -115,10 +116,14 @@ class TestSearchController < TestCase
 
     get "search?q=Integration%20and%20Interoperability&ontologies=#{acronym}"
     results = MultiJson.load(last_response.body)
-    assert_equal 22, results["collection"].length
+
+    assert results["collection"].all? { |x| !x["obsolete"] }
+    count = results["collection"].length
+
     get "search?q=Integration%20and%20Interoperability&ontologies=#{acronym}&also_search_obsolete=false"
     results = MultiJson.load(last_response.body)
-    assert_equal 22, results["collection"].length
+    assert_equal count, results["collection"].length
+
     get "search?q=Integration%20and%20Interoperability&ontologies=#{acronym}&also_search_obsolete=true"
     results = MultiJson.load(last_response.body)
     assert_equal 29, results["collection"].length
@@ -134,8 +139,14 @@ class TestSearchController < TestCase
     # testing cui and semantic_types flags
     get "search?q=Funding%20Resource&ontologies=#{acronym}&include=prefLabel,synonym,definition,notation,cui,semanticType"
     results = MultiJson.load(last_response.body)
-    assert_equal 35, results["collection"].length
-    assert_equal "Funding Resource", results["collection"][0]["prefLabel"]
+    #assert_equal 35, results["collection"].length
+    assert results["collection"].all? do |r|
+      ["prefLabel", "synonym", "definition", "notation", "cui", "semanticType"].map {|x| r[x]}
+                                                                               .flatten
+                                                                               .join(' ')
+                                                                               .include?("Funding Resource")
+    end
+    assert_equal "Funding Resource", results["collection"][0]["prefLabel"].first
     assert_equal "T028", results["collection"][0]["semanticType"][0]
     assert_equal "X123456", results["collection"][0]["cui"][0]
 
@@ -190,7 +201,7 @@ class TestSearchController < TestCase
     assert_equal 10, results["collection"].length
     provisional = results["collection"].select {|res| assert_equal ontology_type, res["ontologyType"]; res["provisional"]}
     assert_equal 1, provisional.length
-    assert_equal @@test_pc_root.label, provisional[0]["prefLabel"]
+    assert_equal @@test_pc_root.label, provisional[0]["prefLabel"].first
 
     # subtree root with provisional class test
     get "search?ontology=#{acronym}&subtree_root_id=#{CGI::escape(@@cls_uri.to_s)}&also_search_provisional=true"
@@ -199,7 +210,7 @@ class TestSearchController < TestCase
 
     provisional = results["collection"].select {|res| res["provisional"]}
     assert_equal 1, provisional.length
-    assert_equal @@test_pc_child.label, provisional[0]["prefLabel"]
+    assert_equal @@test_pc_child.label, provisional[0]["prefLabel"].first
   end
 
 end

--- a/test/middleware/test_rack_attack.rb
+++ b/test/middleware/test_rack_attack.rb
@@ -18,14 +18,14 @@ class TestRackAttack < TestCase
     LinkedData::OntologiesAPI.settings.req_per_second_per_ip = 1
     LinkedData::OntologiesAPI.settings.safe_ips = Set.new(["1.2.3.4", "1.2.3.5"])
 
-    @@user = LinkedData::Models::User.new({username: "user", password: "test_password", email: "test_email@example.org"})
+    @@user = LinkedData::Models::User.new({username: "user", password: "test_password", email: "test_email1@example.org"})
     @@user.save
 
-    @@bp_user = LinkedData::Models::User.new({username: "ncbobioportal", password: "test_password", email: "test_email@example.org"})
+    @@bp_user = LinkedData::Models::User.new({username: "ncbobioportal", password: "test_password", email: "test_email2@example.org"})
     @@bp_user.save
 
     admin_role = LinkedData::Models::Users::Role.find("ADMINISTRATOR").first
-    @@admin = LinkedData::Models::User.new({username: "admin", password: "test_password", email: "test_email@example.org", role: [admin_role]})
+    @@admin = LinkedData::Models::User.new({username: "admin", password: "test_password", email: "test_email3@example.org", role: [admin_role]})
     @@admin.save
 
     # Redirect output or we get a bunch of noise from Rack (gets reset in the after_suite method).

--- a/test/solr/configsets/term_search/conf/schema.xml
+++ b/test/solr/configsets/term_search/conf/schema.xml
@@ -128,11 +128,20 @@
     <field name="resource_id"           type="string"             indexed="true"  stored="true"  multiValued="false" required="true" />
 
     <!-- searchable fields -->
-    <field name="prefLabel"             type="text_general"       indexed="true"  stored="true"  multiValued="false" />
-    <field name="prefLabelExact"        type="string_ci"          indexed="true"  stored="true"  multiValued="false" />
-    <field name="prefLabelSuggest"      type="text_suggest"       indexed="true"  stored="true"  omitNorms="true" />
-    <field name="prefLabelSuggestEdge"  type="text_suggest_edge"  indexed="true"  stored="true" />
-    <field name="prefLabelSuggestNgram" type="text_suggest_ngram" indexed="true"  stored="true"  omitNorms="true" />
+    <!-- all languages fields -->
+    <field name="prefLabel"             type="text_general"       indexed="true"  stored="true"  multiValued="true" />
+    <field name="prefLabelExact"        type="string_ci"          indexed="true"  stored="true"  multiValued="true" />
+    <field name="prefLabelSuggest"      type="text_suggest"       indexed="true"  stored="true"  multiValued="true"  omitNorms="true" />
+    <field name="prefLabelSuggestEdge"  type="text_suggest_edge"  indexed="true"  stored="true"  multiValued="true"  />
+    <field name="prefLabelSuggestNgram" type="text_suggest_ngram" indexed="true"  stored="true"  multiValued="true"  omitNorms="true" />
+
+    <!--  language specific fields  (e.g prefLabel_en or prefLabel_fr) -->
+    <dynamicField name="prefLabel_*" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelExact_*" type="string_ci" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggest_*" type="text_suggest" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggestEdge_*" type="text_suggest_edge" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="prefLabelSuggestNgram_*" type="text_suggest_ngram" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+
 
     <field name="synonym"               type="text_general"       indexed="true"  stored="true"  multiValued="true" />
     <field name="synonymExact"          type="string_ci"          indexed="true"  stored="true"  multiValued="true" />
@@ -140,9 +149,18 @@
     <field name="synonymSuggestEdge"    type="text_suggest_edge"  indexed="true"  stored="true"  multiValued="true" />
     <field name="synonymSuggestNgram"   type="text_suggest_ngram" indexed="true"  stored="true"  omitNorms="true" multiValued="true" />
 
+    <dynamicField name="synonym_*" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymExact_*" type="string_ci" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymSuggest_*" type="text_suggest" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+    <dynamicField name="synonymSuggestEdge_*" type="text_suggest_edge" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="synonymSuggestNgram_*" type="text_suggest_ngram" indexed="true" stored="true" omitNorms="true" multiValued="true" />
+
+
     <field name="notation"              type="text_general"       indexed="true"  stored="true"  multiValued="false" />
 
-    <field name="definition"            type="string"             indexed="true"  stored="true"  multiValued="true" />
+    <field name="definition" type="string" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="definition_*" type="string" indexed="true" stored="true" multiValued="true" />
+
     <field name="submissionAcronym"     type="string"             indexed="true"  stored="true"  multiValued="false" />
     <field name="parents"               type="string"             indexed="true"  stored="true"  multiValued="true" />
     <field name="ontologyType"          type="ontologyType"       indexed="true"  stored="true"  multiValued="false" />
@@ -250,6 +268,17 @@
     <copyField source="synonym" dest="synonymSuggest" />
     <copyField source="synonym" dest="synonymSuggestEdge" />
     <copyField source="synonym" dest="synonymSuggestNgram" />
+
+    <copyField source="prefLabel_*" dest="prefLabelExact_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggest_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggestEdge_*" />
+    <copyField source="prefLabel_*" dest="prefLabelSuggestNgram_*" />
+
+
+    <copyField source="synonym_*" dest="synonymExact_*" />
+    <copyField source="synonym_*" dest="synonymSuggest_*" />
+    <copyField source="synonym_*" dest="synonymSuggestEdge_*" />
+    <copyField source="synonym_*" dest="synonymSuggestNgram_*" />
 
     <copyField source="notation" dest="_text_"/>
 

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -21,7 +21,9 @@ ENV['RACK_ENV'] = 'test'
 require_relative 'test_log_file'
 require_relative '../app'
 require 'minitest/unit'
+require 'webmock/minitest'
 MiniTest::Unit.autorun
+WebMock.allow_net_connect!
 require 'rack/test'
 require 'multi_json'
 require 'oj'


### PR DESCRIPTION
### Context 
See https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/95

### Changes 
- Add access token authentication (https://github.com/ontoportal-lirmm/ontologies_api/commit/2cdd4ffcca18a3c0d44a19b6bfb4744f2c40b15a)
- Refactor user controller to extract reset password helpers (https://github.com/ontoportal-lirmm/ontologies_api/commit/3d05980f8ddf1a6909feb2094e02c981d3751e34)
- Remove the send notification on user creation, now handled by user.save (https://github.com/ontoportal-lirmm/ontologies_api/commit/ae6bdd5fb512cb06ddd7dd0b5c68da8606330d0f)
