### PR TITLE
Fix: display contact for get submissions 

### DIFF
--- a/controllers/admin_controller.rb
+++ b/controllers/admin_controller.rb
@@ -68,7 +68,7 @@ class AdminController < ApplicationController
       latest = ont.latest_submission(status: :any)
       error 404, "Ontology #{params["acronym"]} contains no submissions" if latest.nil?
       check_last_modified(latest)
-      latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param))
+      latest.bring(*submission_include_params)
       NcboCron::Models::OntologySubmissionParser.new.queue_submission(latest, actions)
       halt 204
     end
@@ -84,7 +84,7 @@ class AdminController < ApplicationController
         latest = ont.latest_submission(status: :any)
       end
       check_last_modified(latest) if latest
-      latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param)) if latest
+      latest.bring(*submission_include_params) if latest
       reply(latest || {})
     end
 

--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -38,25 +38,12 @@ class OntologiesController < ApplicationController
       else
         latest = ont.latest_submission(status: :any)
       end
-      check_last_modified(latest) if latest
-      # When asking to display all metadata, we are using bring_remaining which is more performant than including all metadata (remove this when the query to get metadata will be fixed)
+
       if latest
-        if includes_param.first == :all
-          # Bring what we need to display all attr of the submission
-          latest.bring_remaining
-          latest.bring({:contact=>[:name, :email],
-                      :ontology=>[:acronym, :name, :administeredBy, :group, :viewingRestriction, :doNotUpdate, :flat,
-                                  :hasDomain, :summaryOnly, :acl, :viewOf, :ontologyType],
-                      :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym], :metrics =>[:classes, :individuals, :properties]})
-        else
-          includes = OntologySubmission.goo_attrs_to_load(includes_param)
-
-          includes << {:contact=>[:name, :email]} if includes.find{|v| v.is_a?(Hash) && v.keys.first.eql?(:contact)}
-
-          latest.bring(*includes)
-        end
+        check_last_modified(latest)
+        latest.bring(*submission_include_params)
       end
-      #remove the whole previous if block and replace by it: latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param)) if latest
+
       reply(latest || {})
     end
 
@@ -66,7 +53,7 @@ class OntologiesController < ApplicationController
     patch '/:acronym/latest_submission' do
       ont = Ontology.find(params["acronym"]).first
       error 422, "You must provide an existing `acronym` to patch" if ont.nil?
-      
+
       submission = ont.latest_submission(status: :any)
 
       submission.bring(*OntologySubmission.attributes)

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -60,7 +60,7 @@ class OntologySubmissionsController < ApplicationController
       ont.bring(:submissions)
       ont_submission = ont.submission(params["ontology_submission_id"])
       error 404, "`submissionId` not found" if ont_submission.nil?
-      ont_submission.bring(*OntologySubmission.goo_attrs_to_load(includes_param))
+      ont_submission.bring(*submission_include_params)
       reply ont_submission
     end
 

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -29,19 +29,13 @@ class OntologySubmissionsController < ApplicationController
       error 422, "Ontology #{params["acronym"]} does not exist" unless ont
       check_last_modified_segment(LinkedData::Models::OntologySubmission, [ont.acronym])
       check_access(ont)
-      if includes_param.first == :all
-        # When asking to display all metadata, we are using bring_remaining which is more performant than including all metadata (remove this when the query to get metadata will be fixed)
-        ont.bring(submissions: [:released, :creationDate, :status, :submissionId,
-                                {:contact=>[:name, :email], :ontology=>[:administeredBy, :acronym, :name, :summaryOnly, :ontologyType, :viewingRestriction, :acl, :group, :hasDomain, :views, :viewOf, :flat],
-                                 :submissionStatus=>[:code], :hasOntologyLanguage=>[:acronym]}, :submissionStatus], :metrics =>[:classes, :individuals, :properties])
+      options = {
+        also_include_views: params["also_include_views"],
+        status: (params["include_status"] || "ANY")
+      }
+      subs = retrieve_submissions(options)
 
-        ont.submissions.each do |sub|
-          sub.bring_remaining
-        end
-      else
-        ont.bring(submissions: OntologySubmission.goo_attrs_to_load(includes_param))
-      end
-      reply ont.submissions.sort {|a,b| b.submissionId.to_i <=> a.submissionId.to_i }  # descending order of submissionId
+      reply subs.sort {|a,b| b.submissionId.to_i <=> a.submissionId.to_i }  # descending order of submissionId
     end
 
     ##

--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -359,8 +359,6 @@ module Sinatra
 
         latest_submissions = page? ? submissions : {} # latest_submission doest not work with pagination
         submissions.each do |sub|
-          # To retrieve all metadata, but slow when a lot of ontologies
-          sub.bring_remaining   if includes_param.first == :all
           unless page?
             next if include_ready?(options) && !sub.ready?
             next if sub.ontology.nil?

--- a/helpers/submission_helper.rb
+++ b/helpers/submission_helper.rb
@@ -3,6 +3,18 @@ require 'sinatra/base'
 module Sinatra
   module Helpers
     module SubmissionHelper
+      def submission_include_params
+        # When asking to display all metadata, we are using bring_remaining on each submission. Slower but best way to retrieve all attrs
+        includes = OntologySubmission.goo_attrs_to_load(includes_param)
+        if includes.find{|v| v.is_a?(Hash) && v.keys.include?(:ontology)}
+          includes << {:ontology=>[:administeredBy, :acronym, :name, :viewingRestriction, :group, :hasDomain,:notes, :reviews, :projects,:acl, :viewOf]}
+        end
+
+        if includes.find{|v| v.is_a?(Hash) && v.keys.include?(:contact)}
+          includes << {:contact=>[:name, :email]}
+        end
+        includes
+      end
 
       def retrieve_submissions(options)
         status = (options[:status] || "RDF").to_s.upcase

--- a/test/controllers/test_ontology_submissions_controller.rb
+++ b/test/controllers/test_ontology_submissions_controller.rb
@@ -210,4 +210,114 @@ class TestOntologySubmissionsController < TestCase
     submissions = MultiJson.load(last_response.body)
     assert_equal 1, submissions["collection"].length
   end
+
+
+  def test_submissions_default_includes
+    ontology_count = 5
+    num_onts_created, created_ont_acronyms, ontologies = create_ontologies_and_submissions(ont_count: ontology_count, submission_count: 1, submissions_to_process: [])
+
+    submission_default_attributes = LinkedData::Models::OntologySubmission.hypermedia_settings[:serialize_default].map(&:to_s)
+
+    get("/submissions?display_links=false&display_context=false&include_status=ANY")
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+
+    assert_equal ontology_count, submissions.size
+    assert(submissions.all? { |sub| submission_default_attributes.eql?(submission_keys(sub)) })
+
+    get("/ontologies/#{created_ont_acronyms.first}/submissions?display_links=false&display_context=false")
+
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+    assert_equal 1, submissions.size
+    assert(submissions.all? { |sub| submission_default_attributes.eql?(submission_keys(sub)) })
+  end
+
+  def test_submissions_all_includes
+    ontology_count = 5
+    num_onts_created, created_ont_acronyms, ontologies = create_ontologies_and_submissions(ont_count: ontology_count, submission_count: 1, submissions_to_process: [])
+    def submission_all_attributes
+      attrs = OntologySubmission.goo_attrs_to_load([:all])
+      embed_attrs = attrs.select { |x| x.is_a?(Hash) }.first
+
+      attrs.delete_if { |x| x.is_a?(Hash) }.map(&:to_s) + embed_attrs.keys.map(&:to_s)
+    end
+    get("/submissions?include=all&display_links=false&display_context=false")
+
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+    assert_equal ontology_count, submissions.size
+
+    assert(submissions.all? { |sub| submission_all_attributes.sort.eql?(submission_keys(sub).sort) })
+    assert(submissions.all? { |sub| sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])) })
+
+    get("/ontologies/#{created_ont_acronyms.first}/submissions?include=all&display_links=false&display_context=false")
+
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+    assert_equal 1, submissions.size
+
+    assert(submissions.all? { |sub| submission_all_attributes.sort.eql?(submission_keys(sub).sort) })
+    assert(submissions.all? { |sub| sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])) })
+
+    get("/ontologies/#{created_ont_acronyms.first}/latest_submission?include=all&display_links=false&display_context=false")
+    assert last_response.ok?
+    sub = MultiJson.load(last_response.body)
+
+    assert(submission_all_attributes.sort.eql?(submission_keys(sub).sort))
+    assert(sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])))
+
+    get("/ontologies/#{created_ont_acronyms.first}/submissions/1?include=all&display_links=false&display_context=false")
+    assert last_response.ok?
+    sub = MultiJson.load(last_response.body)
+
+    assert(submission_all_attributes.sort.eql?(submission_keys(sub).sort))
+    assert(sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])))
+  end
+
+  def test_submissions_custom_includes
+    ontology_count = 5
+    num_onts_created, created_ont_acronyms, ontologies = create_ontologies_and_submissions(ont_count: ontology_count, submission_count: 1, submissions_to_process: [])
+    include = 'ontology,contact,submissionId'
+
+    get("/submissions?include=#{include}&display_links=false&display_context=false")
+
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+    assert_equal ontology_count, submissions.size
+    assert(submissions.all? { |sub| include.split(',').eql?(submission_keys(sub)) })
+    assert(submissions.all? { |sub| sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])) })
+
+    get("/ontologies/#{created_ont_acronyms.first}/submissions?include=#{include}&display_links=false&display_context=false")
+
+    assert last_response.ok?
+    submissions = MultiJson.load(last_response.body)
+    assert_equal 1, submissions.size
+    assert(submissions.all? { |sub| include.split(',').eql?(submission_keys(sub)) })
+    assert(submissions.all? { |sub| sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])) })
+
+    get("/ontologies/#{created_ont_acronyms.first}/latest_submission?include=#{include}&display_links=false&display_context=false")
+    assert last_response.ok?
+    sub = MultiJson.load(last_response.body)
+    assert(include.split(',').eql?(submission_keys(sub)))
+    assert(sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])))
+
+    get("/ontologies/#{created_ont_acronyms.first}/submissions/1?include=#{include}&display_links=false&display_context=false")
+    assert last_response.ok?
+    sub = MultiJson.load(last_response.body)
+    assert(include.split(',').eql?(submission_keys(sub)))
+    assert(sub["contact"] && (sub["contact"].first.nil? || sub["contact"].first.keys.eql?(%w[name email id])))
+  end
+
+  def test_submissions_param_include
+    skip('only for local development regrouping a set of tests')
+    test_submissions_default_includes
+    test_submissions_all_includes
+    test_submissions_custom_includes
+  end
+
+  private
+  def submission_keys(sub)
+    sub.to_hash.keys - %w[@id @type id]
+  end
 end


### PR DESCRIPTION
### Context

A temporary fix for https://github.com/ontoportal-lirmm/ontologies_api/issues/22 , while https://github.com/ontoportal-lirmm/goo/issues/46 is not fixed.

This PR also includes a small fix but with a big response time optimization. As the bellow benchmark shows, the endpoints `/submissions?include=all` and `/ontologies/:acronym/submissions?include=all` are now **40 times** and **6 times** faster.


Use case, a fresh database with 5 ontologies and 25 submissions:
Test | Time before optimization | Time after optimization | Improvement %
-- | -- | -- | --
get all submissions (25 submissions with 12 attributes) | 0.219019 | 0.217481 | same
get all submissions with include all (25 submissions with 119 attributes) | 10.967734 | 0.243821 | 44x faster
get ontology TEST-ONT-0 submissions (5 submissions with 12 attributes) | 0.043980 | 0.050559 | same
get ontology TEST-ONT-0 submissions with include all (5 submissions with 119 attributes) | 0.455594 | 0.067641 | 6x faster


This improvement was made by removing this no-more-needed line https://github.com/ontoportal-lirmm/ontologies_api/pull/45/files#diff-20027d6ce1351a4089be545b94f15a4f6a3f771c433ac37a70874918e06b9986L366
 
### Changes 
- Refactor and extract submission_include_params helper, to get what attribute to include in a request (https://github.com/ontoportal-lirmm/ontologies_api/pull/45/commits/62c7b0e54b1e6a517d2be1e4d2deb134625a1ade)