### PR TITLE
Fix: remove ontology creation notification because replaced with submission creation

### DIFF
--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -176,13 +176,6 @@ class OntologiesController < ApplicationController
 
       if ont.valid?
         ont.save
-        # Send an email to the administrator to warn him about the newly created ontology
-        begin
-          if !LinkedData.settings.admin_emails.nil? && !LinkedData.settings.admin_emails.empty?
-            LinkedData::Utils::Notifications.new_ontology(ont)
-          end
-        rescue Exception => e
-        end
       else
         error 422, ont.errors
       end


### PR DESCRIPTION
With the new workflow of creating ontologies. As the form of the ontology and submission is the same, sometimes we can have an ontology valid and created but the submission part is erroneous, so for now we create an ontology on each save and remove it if the submission is not valid. (we can't test the validity of an orphan submission) 

This raises an issue which is that we send a notification of ontology creation even if it's removed just after because of its no validity.

This is a temporary fix until we do an iteration on the notification system. where before we had two notifications, one when an ontology is created and one when the submission is parsed. Now only the latter is sent and we removed the ontology creation notification sent to the admins.

