### PR TITLE
Fix: include all metrics attribues in the submissions endpoints

### DIFF
--- a/helpers/submission_helper.rb
+++ b/helpers/submission_helper.rb
@@ -13,6 +13,14 @@ module Sinatra
         if includes.find{|v| v.is_a?(Hash) && v.keys.include?(:contact)}
           includes << {:contact=>[:name, :email]}
         end
+
+        if includes.find{|v| v.is_a?(Hash) && v.keys.include?(:metrics)}
+          includes << { metrics: [:maxChildCount, :properties, :classesWithMoreThan25Children,
+                                  :classesWithOneChild, :individuals, :maxDepth, :classes,
+                                  :classesWithNoDefinition, :averageChildCount, :numberOfAxioms,
+                                  :entities]}
+        end
+
         includes
       end
 


### PR DESCRIPTION
Follow up of https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/104
To fix this display of all attributes of metrics object in the submission endpoint

From 
<img width="940" alt="image" src="https://github.com/ontoportal-lirmm/ontologies_api/assets/29259906/f26f21fb-2853-46b2-937a-181a17ef1d10">
To 
<img width="940" alt="image" src="https://github.com/ontoportal-lirmm/ontologies_api/assets/29259906/205929a6-369c-4017-9769-a27294dc9239">
