### PR TITLE
Feature: add analytics controller with  endpoints for users, ontologies and pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: a199eff007f5d7f18205d61194f3823445aa6460
+  revision: d5af89ba5563cbd9bfc06c51a8330015dd737614
   branch: development
   specs:
     ontologies_linked_data (0.0.1)
@@ -216,7 +216,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.3.0)
     net-http-persistent (2.9.4)
-    net-imap (0.4.6)
+    net-imap (0.4.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/controllers/analytics_controller.rb
+++ b/controllers/analytics_controller.rb
@@ -1,0 +1,45 @@
+require 'csv'
+
+class OntologyAnalyticsController < ApplicationController
+
+  ##
+  # get all ontology analytics for a given year/month combination
+  # TODO use a namespace analytics after migration the old OntologyAnalyticsController
+  namespace "/data/analytics" do
+
+    get 'ontologies' do
+      expires 86400, :public
+      year = year_param(params)
+      error 400, "The year you supplied is invalid. Valid years start with 2 and contain 4 digits." if params["year"] && !year
+      month = month_param(params)
+      error 400, "The month you supplied is invalid. Valid months are 1-12." if params["month"] && !month
+      acronyms = restricted_ontologies_to_acronyms(params)
+      analytics = Ontology.analytics(year, month, acronyms)
+
+      reply analytics
+    end
+
+
+    get 'users' do
+      expires 86400, :public
+      year = year_param(params)
+      error 400, "The year you supplied is invalid. Valid years start with 2 and contain 4 digits." if params["year"] && !year
+      month = month_param(params)
+      error 400, "The month you supplied is invalid. Valid months are 1-12." if params["month"] && !month
+      analytics = User.analytics(year, month)
+      reply analytics['all_users']
+    end
+
+    get 'page_visits' do
+      expires 86400, :public
+      year = year_param(params)
+      error 400, "The year you supplied is invalid. Valid years start with 2 and contain 4 digits." if params["year"] && !year
+      month = month_param(params)
+      error 400, "The month you supplied is invalid. Valid months are 1-12." if params["month"] && !month
+      analytics = User.page_visits_analytics
+      reply analytics['all_pages']
+    end
+
+  end
+
+end

--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -276,7 +276,7 @@ module Sinatra
         if params["month"]
           month = params["month"].strip
           if %r{(?<month>^(0[1-9]|[1-9]|1[0-2])$)}x === month
-            month.to_i
+            month.to_i.to_s
           end
         end
       end
@@ -287,7 +287,7 @@ module Sinatra
         if params["year"]
           year = params["year"].strip
           if %r{(?<year>^([1-2]\d{3})$)}x === year
-            year.to_i
+            year.to_i.to_s
           end
         end
       end

--- a/test/controllers/test_annotator_controller.rb
+++ b/test/controllers/test_annotator_controller.rb
@@ -260,16 +260,16 @@ eos
     assert last_response.ok?
     annotations = MultiJson.load(last_response.body)
     assert_equal 9, annotations.length
-    annotations.sort! { |a,b| a["annotatedClass"]["prefLabel"].downcase <=> b["annotatedClass"]["prefLabel"].downcase }
+    annotations.sort! { |a,b| a["annotatedClass"]["prefLabel"].first.downcase <=> b["annotatedClass"]["prefLabel"].first.downcase }
     assert_equal "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Aggregate_Human_Data", annotations.first["annotatedClass"]["@id"]
-    assert_equal "Aggregate Human Data", annotations.first["annotatedClass"]["prefLabel"]
+    assert_equal "Aggregate Human Data", Array(annotations.first["annotatedClass"]["prefLabel"]).first
 
     params = {text: text, include: "prefLabel,definition"}
     get "/annotator", params
     assert last_response.ok?
     annotations = MultiJson.load(last_response.body)
     assert_equal 9, annotations.length
-    annotations.sort! { |a,b| a["annotatedClass"]["prefLabel"].downcase <=> b["annotatedClass"]["prefLabel"].downcase }
+    annotations.sort! { |a,b| Array(a["annotatedClass"]["prefLabel"]).first.downcase <=> Array(b["annotatedClass"]["prefLabel"]).first.downcase }
     assert_equal "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Aggregate_Human_Data", annotations.first["annotatedClass"]["@id"]
     assert_equal ["A resource that provides data from clinical care that comprises combined data from multiple individual human subjects."], annotations.first["annotatedClass"]["definition"]
   end

--- a/test/controllers/test_mappings_controller.rb
+++ b/test/controllers/test_mappings_controller.rb
@@ -245,7 +245,7 @@ class TestMappingsController < TestCase
     get "/ontologies/#{ontology}/mappings?pagesize=#{pagesize}&page=#{page}&display=prefLabel"
     assert last_response.ok?
     mappings = MultiJson.load(last_response.body)
-    assert mappings["collection"].all? { |m| m["classes"].all? { |c| c["prefLabel"].is_a?(String) && c["prefLabel"].length > 0 } }
+    assert mappings["collection"].all? { |m| m["classes"].all? { |c| c["prefLabel"].first.is_a?(String) && c["prefLabel"].first.length > 0 } }
 
     def_count = 0
     next_page = 1

--- a/test/controllers/test_ontology_analytics_controller.rb
+++ b/test/controllers/test_ontology_analytics_controller.rb
@@ -203,7 +203,9 @@ class TestOntologyAnalyticsController < TestCase
       puts "   This test cannot be run because there #{db_size} redis entries (max #{MAX_TEST_REDIS_SIZE}). You are probably pointing to the wrong redis backend. "
       return
     end
-    @@redis.set(LinkedData::Models::Ontology::ONTOLOGY_ANALYTICS_REDIS_FIELD, Marshal.dump(ANALYTICS_DATA))
+
+    stringy_keys = ANALYTICS_DATA.transform_values{|year| year.map{|k,v| [k.to_s , v.stringify_keys]}.to_h}
+    @@redis.set(LinkedData::Models::Ontology::ONTOLOGY_ANALYTICS_REDIS_FIELD, Marshal.dump(stringy_keys))
     @@onts = {
         "NCIT" => "NCIT Ontology",
         "ONTOMA" => "ONTOMA Ontology",


### PR DESCRIPTION
### Prerequisites 
* https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/118
### Changes 

* Add `/data/analytics/ontologies` endpoint, to get ontologies visits evolution by time.
* Add `/data/analytics/users` endpoint, to get users visits   evolution by time. 
* Add `/data/analytics/page_visits` endpoint, to get top pages visited in the current month. 