### PR TITLE
Feature: Add accessibility security to ontology metadata & content search results 

### DIFF
--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -22,7 +22,7 @@ class SearchController < ApplicationController
         format = params.fetch("hasOntologyLanguage", "").split(',')
         is_of_type = params.fetch("isOfType", "").split(',')
         has_format = params.fetch("hasFormat", "").split(',')
-        visibility = params["visibility"]&.presence || "public"
+        visibility = params["visibility"]
         show_views = params["show_views"] == 'true'
         sort = params.fetch("sort", "score desc, ontology_name_sort asc, ontology_acronym_sort asc")
         page, page_size = page_params
@@ -30,12 +30,12 @@ class SearchController < ApplicationController
         fq = [
           'resource_model:"ontology_submission"',
           'submissionStatus_txt:ERROR_* OR submissionStatus_txt:"RDF" OR submissionStatus_txt:"UPLOADED"',
-          "ontology_viewingRestriction_t:#{visibility}",
           groups.map { |x| "ontology_group_txt:\"http://data.bioontology.org/groups/#{x.upcase}\"" }.join(' OR '),
           categories.map { |x| "ontology_hasDomain_txt:\"http://data.bioontology.org/categories/#{x.upcase}\"" }.join(' OR '),
           languages.map { |x| "naturalLanguage_txt:\"#{x.downcase}\"" }.join(' OR '),
         ]
 
+        fq << "ontology_viewingRestriction_t:#{visibility}" unless visibility.blank?
         fq << "!ontology_viewOf_t:*" unless show_views
 
         fq << format.map { |x| "hasOntologyLanguage_t:\"http://data.bioontology.org/ontology_formats/#{x}\"" }.join(' OR ') unless format.blank?
@@ -75,7 +75,15 @@ class SearchController < ApplicationController
           old_resource_id = acronyms_ids[acronym]
           old_id = old_resource_id.split('/').last.to_i rescue 0
 
-          if acronym.blank? || old_id && id && (id <= old_id)
+          already_found = (old_id && id && (id <= old_id))
+          not_restricted = (doc["ontology_viewingRestriction_t"]&.eql?('public') || current_user&.admin?)
+          user_not_restricted = not_restricted ||
+            Array(doc["ontology_viewingRestriction_txt"]).any? {|u| u.split(' ').last == current_user&.username} ||
+            Array(doc["ontology_acl_txt"]).any? {|u| u.split(' ').last == current_user&.username}
+
+          user_restricted = !user_not_restricted
+
+          if acronym.blank? || already_found || user_restricted
             total_found -= 1
             next
           end

--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -200,11 +200,6 @@ class SearchController < ApplicationController
       }
     end
 
-
-    def search_ontologies
-
-    end
-
     def process_search(params = nil)
       params ||= @params
       text = params["q"]


### PR DESCRIPTION
### Changes

* Add ontology accessibility restriction to ontology metadata search (https://github.com/ontoportal-lirmm/ontologies_api/commit/6a4de67c32922e819ec76306d370227a2f5c3a7c)
* Add ontology accessibility restriction to ontology content search (https://github.com/ontoportal-lirmm/ontologies_api/commit/486748a8579d6305daf7b35215e63cd85de6e445)
* Add search results accessibility security test (https://github.com/ontoportal-lirmm/ontologies_api/commit/7504a63109d365531a007666a0d333200f09c49c)