### PR TITLE
Feature: mappings statistics slices support

### DIFF
--- a/controllers/mappings_controller.rb
+++ b/controllers/mappings_controller.rb
@@ -191,6 +191,8 @@ class MappingsController < ApplicationController
                                       .each do |m|
         persistent_counts[m.ontologies.first] = m.count
       end
+      ont_acronyms = restricted_ontologies_to_acronyms(params)
+      persistent_counts = persistent_counts.select { |key, _| ont_acronyms.include?(key) || key.start_with?("http://") }
       reply persistent_counts
     end
 

--- a/test/controllers/test_mappings_controller.rb
+++ b/test/controllers/test_mappings_controller.rb
@@ -88,11 +88,6 @@ class TestMappingsController < TestCase
     commun_created_mappings_test(created, mapping_term_a, mapping_term_b, relations)
   end
 
-  def test_mappings_slices
-    get "/mappings/statistics/ontologies/"
-    
-    
-  end
 
   private
 

--- a/test/controllers/test_mappings_controller.rb
+++ b/test/controllers/test_mappings_controller.rb
@@ -88,6 +88,12 @@ class TestMappingsController < TestCase
     commun_created_mappings_test(created, mapping_term_a, mapping_term_b, relations)
   end
 
+  def test_mappings_slices
+    get "/mappings/statistics/ontologies/"
+    
+    
+  end
+
   private
 
   def commun_created_mappings_test(created, mapping_term_a, mapping_term_b, relations)
@@ -423,4 +429,6 @@ class TestMappingsController < TestCase
     end
     [mappings, mapping_ont_a, mapping_ont_b, mapping_term_a, mapping_term_b, relations]
   end
+
+  
 end

--- a/test/helpers/test_slices_helper.rb
+++ b/test/helpers/test_slices_helper.rb
@@ -70,6 +70,31 @@ class TestSlicesHelper < TestCaseHelpers
     assert results.all? {|r| group_ids.include?(r["links"]["ontology"])}
   end
 
+  def test_mappings_slices
+    LinkedData::Mappings.create_mapping_counts(Logger.new(TestLogFile.new))
+
+    get "/mappings/statistics/ontologies/"
+    
+    expected_result_without_slice = ["PARSED-0",
+      "PARSED-1",
+      "http://data.bioontology.org/metadata/ExternalMappings",
+      "http://data.bioontology.org/metadata/InterportalMappings/agroportal",
+      "http://data.bioontology.org/metadata/InterportalMappings/ncbo",
+      "http://data.bioontology.org/metadata/InterportalMappings/sifr"]
+
+    assert_equal expected_result_without_slice, MultiJson.load(last_response.body).keys.sort
+
+    get "http://#{@@group_acronym}/mappings/statistics/ontologies/"
+
+    expected_result_with_slice = ["PARSED-0",
+      "http://data.bioontology.org/metadata/ExternalMappings",
+      "http://data.bioontology.org/metadata/InterportalMappings/agroportal",
+      "http://data.bioontology.org/metadata/InterportalMappings/ncbo",
+      "http://data.bioontology.org/metadata/InterportalMappings/sifr"]
+
+    assert_equal expected_result_with_slice, MultiJson.load(last_response.body).keys.sort
+  end
+
   private
 
   def self._create_group


### PR DESCRIPTION
#### Done
- Made the endpoint `/mappings/statistics/ontologies/` supports slices (when we call it from a slice then limit the ontologies only to the ontologies of this slice)
- Add a test for that