### PR TITLE
Fix: Annotator request size limit 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bigdecimal (1.4.2)
     builder (3.2.4)
     capistrano (3.18.1)
@@ -197,6 +198,7 @@ GEM
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.4.0)
+    google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos (1.5.0)
       google-protobuf (~> 3.18)
@@ -211,6 +213,9 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    grpc (1.64.0-x86_64-darwin)
+      google-protobuf (~> 3.25)
+      googleapis-common-protos-types (~> 1.0)
     grpc (1.64.0-x86_64-linux)
       google-protobuf (~> 3.25)
       googleapis-common-protos-types (~> 1.0)
@@ -407,6 +412,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -464,4 +470,4 @@ DEPENDENCIES
   webmock (~> 3.19.1)
 
 BUNDLED WITH
-   2.3.23
+   2.4.22

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -333,7 +333,7 @@ module Sinatra
         params["fq"] << " AND #{get_quoted_field_query_param(class_ids, "OR", "resource_id")}"
         params["rows"] = 99999
         # Replace fake query with wildcard
-        resp = LinkedData::Models::Class.search("*:*", params)
+        resp = LinkedData::Models::Class.submit_search_query("*:*", params)
 
         classes_hash = {}
         resp["response"]["docs"].each do |doc|

--- a/test/controllers/test_search_models_controller.rb
+++ b/test/controllers/test_search_models_controller.rb
@@ -8,6 +8,7 @@ class TestSearchModelsController < TestCase
     LinkedData::Models::Agent.indexClear
     LinkedData::Models::Class.indexClear
     LinkedData::Models::OntologyProperty.indexClear
+    Goo.init_search_connection(:ontology_data)
   end
 
   def setup


### PR DESCRIPTION
Fix https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/612  which is returning an error because after the annotation fetched we populate them with the index data, but as the result are too big, we overfow the limit of what an URL get request can have. We can this error in the API logs 
![image](https://github.com/ontoportal-lirmm/ontologies_api/assets/29259906/0342b6bf-d661-45df-9cb5-36b0a63851af)





This PR fix that  by using `submit_search_query` to call SOLR using POST not GET (https://github.com/ontoportal-lirmm/ontologies_api/commit/2b9503a92f876d8b461baa235008a3e0bf39fa6d) 
