### PR TITLE
Fix: Agents search sensibility

### DIFF
--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -63,7 +63,7 @@ class SearchController < ApplicationController
           page_size: page_size,
           sort: sort
         })
-        
+
         total_found = page_data.aggregate
         ontology_rank = LinkedData::Models::Ontology.rank
         docs = {}
@@ -154,7 +154,6 @@ class SearchController < ApplicationController
         fq = "agentType_t:#{type}" if type
 
         qf = [
-          "acronymSuggestEdge^25  nameSuggestEdge^15 emailSuggestEdge^15 identifiersSuggestEdge^10 ", # start of the word first
           "identifiers_texts^20 acronym_text^15  name_text^10 email_text^10 ", # full word match
           "acronymSuggestNgram^2 nameSuggestNgram^1.5 email_text^1" # substring match last
         ].join(' ')

--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -153,7 +153,17 @@ class SearchController < ApplicationController
 
         fq = "agentType_t:#{type}" if type
 
-        qf = "identifiers_texts^20 acronym_text^15  name_text^10 email_text^10" # full word match
+        if params[:qf]
+          qf = params[:qf]
+        else
+          qf = [
+            "acronymSuggestEdge^25  nameSuggestEdge^15 emailSuggestEdge^15 identifiersSuggestEdge^10 ", # start of the word first
+            "identifiers_texts^20 acronym_text^15  name_text^10 email_text^10 ", # full word match
+            "acronymSuggestNgram^2 nameSuggestNgram^1.5 email_text^1" # substring match last
+          ].join(' ')
+        end
+
+
 
         if params[:sort]
           sort = "#{params[:sort]} asc, score desc"

--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -153,10 +153,7 @@ class SearchController < ApplicationController
 
         fq = "agentType_t:#{type}" if type
 
-        qf = [
-          "identifiers_texts^20 acronym_text^15  name_text^10 email_text^10 ", # full word match
-          "acronymSuggestNgram^2 nameSuggestNgram^1.5 email_text^1" # substring match last
-        ].join(' ')
+        qf = "identifiers_texts^20 acronym_text^15  name_text^10 email_text^10" # full word match
 
         if params[:sort]
           sort = "#{params[:sort]} asc, score desc"


### PR DESCRIPTION
### Issue description
When we search for example for the query = abcdefghijklmnopqrstuvwxyz 
we get 36 agents (https://data.stageportal.lirmm.fr/search/agents?query=abcdefghijklmnopqrstuvwxyz)
 and the expected behavior is to get no agent

### Solution
Changed the search query logic passed to Solr to make it match only Strings and substrings rather than individual letters