### PR TITLE
Fix: Agent search not working well

### DIFF
--- a/controllers/search_controller.rb
+++ b/controllers/search_controller.rb
@@ -148,6 +148,7 @@ class SearchController < ApplicationController
     namespace "/agents" do
       get do
         query = params[:query] || params[:q]
+        query = "#{query}*"
         page, page_size = page_params
         type = params[:agentType].blank? ? nil : params[:agentType]
 


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/799

### Changes
- Add `*` to the search query of the endpoint `/search/agents`