### PR TITLE
Fix: explicitly load `resetTokenExpireTime` in password reset

### DIFF
--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -44,6 +44,7 @@ module Sinatra
 
         user.bring(:resetToken)
         user.bring(:passwordHash)
+        user.bring(:resetTokenExpireTime)
         user.show_apikey = true
         token_accepted = token.eql?(user.resetToken)
         if token_accepted

--- a/helpers/users_helper.rb
+++ b/helpers/users_helper.rb
@@ -38,13 +38,10 @@ module Sinatra
       end
 
       def reset_password(email, username, token)
-        user = LinkedData::Models::User.where(email: email, username: username).include(User.goo_attrs_to_load(includes_param)).first
+        user = LinkedData::Models::User.where(email: email, username: username).include(User.goo_attrs_to_load(includes_param) + [:resetToken, :passwordHash, :resetTokenExpireTime]).first
 
         error 404, "User not found" unless user
 
-        user.bring(:resetToken)
-        user.bring(:passwordHash)
-        user.bring(:resetTokenExpireTime)
         user.show_apikey = true
         token_accepted = token.eql?(user.resetToken)
         if token_accepted


### PR DESCRIPTION
Related to this https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/170