### PR TITLE
Fix: hide private ontologies for non admin users in groups controller

### DIFF
--- a/controllers/categories_controller.rb
+++ b/controllers/categories_controller.rb
@@ -14,7 +14,7 @@ class CategoriesController < ApplicationController
     get do
       check_last_modified_collection(LinkedData::Models::Category)
       categories = Category.where.include(*Category.goo_attrs_to_load(includes_param), ontologies: [:viewingRestriction]).to_a
-      categories = reject_private_ontologies(categories) unless current_user.admin? # only portal admin can see private ontologies
+      categories = reject_private_ontologies(categories) unless current_user.admin?
       reply categories
     end
 
@@ -24,7 +24,7 @@ class CategoriesController < ApplicationController
       acronym = params["acronym"]
       category = Category.find(acronym).include(*Category.goo_attrs_to_load(includes_param), ontologies: [:viewingRestriction]).first
       error 404, "Category #{acronym} not found" if category.nil?
-      category = reject_private_ontologies([category]).first unless current_user.admin? # only portal admin can see private ontologies
+      category = reject_private_ontologies([category]).first unless current_user.admin?
       reply 200, category
     end
 
@@ -85,12 +85,6 @@ class CategoriesController < ApplicationController
       reply 201, category
     end
 
-    def reject_private_ontologies(categories)
-      categories.each do |category|
-        public_ontologies = category.ontologies.reject { |ontology| ontology.viewingRestriction == "private" }
-        category.instance_variable_set(:@ontologies, public_ontologies)
-      end
-    end
 
   end
 end

--- a/controllers/groups_controller.rb
+++ b/controllers/groups_controller.rb
@@ -14,7 +14,6 @@ class GroupsController < ApplicationController
     get do
       check_last_modified_collection(LinkedData::Models::Group)
       groups = Group.where.include(*Group.goo_attrs_to_load(includes_param), ontologies: [:viewingRestriction]).to_a
-      # Private ontologies viewd only by admins of the portal
       groups = reject_private_ontologies(groups) unless current_user.admin?
       reply groups
     end
@@ -25,7 +24,6 @@ class GroupsController < ApplicationController
       acronym = params["acronym"]
       g = Group.find(acronym).include(*Group.goo_attrs_to_load(includes_param), ontologies: [:viewingRestriction]).first
       error 404, "Group #{acronym} not found" if g.nil?
-      # Private ontologies viewd only by admins of the portal
       g = reject_private_ontologies([g]).first unless current_user.admin?
       reply 200, g
     end
@@ -86,12 +84,6 @@ class GroupsController < ApplicationController
       reply 201, group
     end
     
-    def reject_private_ontologies(groups)
-      groups.each do |group|
-        public_ontologies = group.ontologies.reject { |ontology| ontology.viewingRestriction == "private" }
-        group.instance_variable_set(:@ontologies, public_ontologies)
-      end
-    end
 
   end
 end

--- a/helpers/ontology_helper.rb
+++ b/helpers/ontology_helper.rb
@@ -75,6 +75,15 @@ module Sinatra
         end
         return filename, tmpfile
       end
+
+      # reject private ontologies in groups and categories 
+      def reject_private_ontologies(items)
+        items.each do |item|
+          public_ontologies = item.ontologies.reject { |ontology| ontology.viewingRestriction == "private" }
+          item.instance_variable_set(:@ontologies, public_ontologies)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fix for: https://github.com/ontoportal-lirmm/ontologies_api/issues/94

### Changes
Reject showing private ontologies for non admin users when accessing `/groups`, `/groups/:acronym`, `/categories`, `/categories/:acronym`. 

