### PR TITLE
Feature: Implement MOD-API routes

### DIFF
--- a/controllers/artefacts.rb
+++ b/controllers/artefacts.rb
@@ -3,10 +3,9 @@ class ArtefactsController < ApplicationController
     namespace "/artefacts" do
         # Get all Semantic Artefacts
         get do
-            artefacts = nil
             check_last_modified_collection(LinkedData::Models::SemanticArtefact)
             options = {
-                allow_views: params['also_include_views'] ||= false,
+                also_include_views: params['also_include_views'] ||= false,
                 includes: LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
             }
             artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(options)

--- a/controllers/artefacts.rb
+++ b/controllers/artefacts.rb
@@ -1,0 +1,27 @@
+class ArtefactsController < ApplicationController
+
+    namespace "/artefacts" do
+        # Get all Semantic Artefacts
+        get do
+            artefacts = nil
+            check_last_modified_collection(LinkedData::Models::SemanticArtefact)
+            options = {
+                allow_views: params['also_include_views'] ||= false,
+                includes: LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
+            }
+            artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(options)
+            reply artefacts
+        end
+
+        # Get one semantic artefact by ID
+        get "/:artefactID" do
+            artefact = LinkedData::Models::SemanticArtefact.find(params["artefactID"])
+            error 404, "You must provide a valid `artefactID` to retrieve an artefact" if artefact.nil?
+            check_last_modified(artefact)
+            artefact.bring(*LinkedData::Models::SemanticArtefact.goo_attrs_to_load(includes_param))
+            reply artefact
+        end
+
+    end
+
+end


### PR DESCRIPTION
### Context

This pull request introduces the implementation of various routes for the MOD-API, enabling access to artefact and distribution data.

### Implemented Routes Overview

| **Route**   | **Description** | **Expected Result** | **HTTP Status Codes**  | **Parameters** |
|-------------------|-------------------------|-------------------------------|-------------------------------------|--------------------------|
| `GET /artefacts` | Retrieves a list of all artefacts. | A list of artefacts in JSON format. | `200 OK`,   `404 Not Found`  | `display`         |
| `GET /artefacts/:artefactID`                       | Retrieves details of a specific artefact.        | Artefact details in JSON format.            | `200 OK`, `404 Not Found`  | `display`                     |
| `GET /artefacts/:artefactID/distributions`         | Lists all distributions of an artefact.          | A list of distributions in JSON format.     | `200 OK`, `404 Not Found`  | `display`                     |
| `GET /artefacts/:artefactID/distributions/:distributionID` | Retrieves a specific distribution of an artefact. | Distribution details in JSON format.        | `200 OK`, `404 Not Found`  | `display`                     |
| `GET /artefacts/:artefactID/distributions/latest`  | Retrieves the latest distribution of an artefact.| Latest distribution details in JSON format. | `200 OK`, `404 Not Found`  | `display`                     |


