### PR TITLE
Fix: Configure GOO cache and HTTP cache to use `redis-ut` as hostname

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,10 @@ ONTOLOGIES_LINKED_DATA_PATH=
 GOO_PATH=
 SPARQL_CLIENT_PATH=
 
+REDIS_GOO_CACHE_HOST=redis-ut
+REDIS_HTTP_CACHE_HOST=redis-ut
+REDIS_PERSISTENT_HOST=redis-ut
+
 ## An ontology that will be imported in the starting of the API server
 STARTER_ONTOLOGY=STY
 ## API key of a remote API used to download the starter ontology


### PR DESCRIPTION
The application was unable to connect to Redis due to missing environment variables specifying the Redis host. The API expected Redis connections for caching (GOO cache, HTTP cache) to be at localhost, this resulted in connection errors when trying to access Redis services.

![image](https://github.com/user-attachments/assets/75511586-43ca-46dc-9739-93509552f234)
