### PR TITLE
Fix: add paging by default to /artefacts

### DIFF
--- a/controllers/artefacts.rb
+++ b/controllers/artefacts.rb
@@ -4,11 +4,9 @@ class ArtefactsController < ApplicationController
         # Get all Semantic Artefacts
         get do
             check_last_modified_collection(LinkedData::Models::SemanticArtefact)
-            options = {
-                also_include_views: params['also_include_views'] ||= false,
-                includes: LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
-            }
-            artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(options)
+            attributes, page, pagesize, _, _ = settings_params(LinkedData::Models::SemanticArtefact)
+            pagesize = 20 if params["pagesize"].nil?
+            artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
             reply artefacts
         end
 


### PR DESCRIPTION
- see: https://github.com/ontoportal-lirmm/ontologies_api/issues/124
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/192

### Solution
Activate the paging by default to /artefacts route
![Screenshot from 2025-02-13 19-32-25](https://github.com/user-attachments/assets/3b30c4e6-e9b5-4df7-aa36-b6f1137f4952)
![Screenshot from 2025-02-13 19-32-11](https://github.com/user-attachments/assets/87270f27-5a4e-462f-b107-f69cc0fd4f5d)


