### PR TITLE
Fix: Remove appuser from the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,6 @@ COPY . .
 RUN cp config/environments/config.rb.sample config/environments/development.rb && \
     cp config/environments/config.rb.sample config/environments/production.rb
 
-# Create non-root user
-RUN adduser --disabled-password --gecos "" appuser && \
-    chown -R appuser:appuser /srv/ontoportal
-
 # Expose port
 EXPOSE 9393
 


### PR DESCRIPTION
see issue: https://github.com/ontoportal-lirmm/ontologies_api/issues/132

Solution it to remove the appuser as it's not doing anything and it's causing ownership errors when running bundle install with local code