### PR TITLE
add pandoc so to render the documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
          git \
          curl \
          libffi-dev \
+         pandoc \
      pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Context
without pandoc we have this error
![image](https://github.com/user-attachments/assets/1132098d-1bff-409e-9bb4-f2c00a8fe7af)


solution is just add pandoc installation in Dockerfile

![image](https://github.com/user-attachments/assets/110e732f-d7a1-454b-942b-8f4956a0eed4)
