### PR TITLE
Hotfix: add file command in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
          git \
          curl \
          libffi-dev \
+         file \
          pandoc \
      pkg-config && \
     apt-get clean && \


### PR DESCRIPTION
### Context
- Without the file command installed in the docker image we will have problems when deleting ontologies because it's uses file command in ontologies_linked_data
     - Deleting an ontology have this error because of this 
```
Errno::ENOENT: No such file or directory - file
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/utils/file.rb:23:in ``'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/utils/file.rb:23:in `zip?'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/ontology_submission.rb:434:in `zipped?'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb:41:in `zip_submission_uploaded_file'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb:36:in `archive_submission'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/services/submission_process/operations/submission_archiver.rb:10:in `process'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/concerns/submission_process.rb:42:in `archive'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/ontology_submission.rb:661:in `delete'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/ontology.rb:417:in `block in delete'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/ontology.rb:416:in `each'
	/srv/ontoportal/ontologies_linked_data/lib/ontologies_linked_data/models/ontology.rb:416:in `delete'
	/srv/ontoportal/ontologies_api/controllers/ontologies_controller.rb:128:in `block (2 levels) in <class:OntologiesController>'
```

  - this one is affecting the system tests of the UI: https://github.com/ontoportal-lirmm/bioportal_web_ui/actions/runs/13562576731/job/37924186634#step:9:1591 