### PR TITLE
Feature: optimize metrics controller

### DIFF
--- a/controllers/metrics_controller.rb
+++ b/controllers/metrics_controller.rb
@@ -4,31 +4,10 @@ class MetricsController < ApplicationController
     # Display all metrics
     get do
       check_last_modified_collection(LinkedData::Models::Metric)
-      submissions = retrieve_latest_submissions(params)
-      submissions = submissions.values
-
-      metrics_include = LinkedData::Models::Metric.goo_attrs_to_load(includes_param)
-      LinkedData::Models::OntologySubmission.where.models(submissions)
-                         .include(metrics: metrics_include).all
-
-      #just a fallback or metrics that are not really built.
-      to_remove = []
-      submissions.each do |x|
-        if x.metrics
-          begin
-            x.metrics.submission
-          rescue
-            LOGGER.error("submission with inconsistent metrics #{x.id.to_s}")
-            to_remove << x
-          end
-        end
-      end
-      to_remove.each do |x|
-        submissions.delete x
-      end
-      #end fallback
-
-      reply submissions.select { |s| !s.metrics.nil? }.map { |s| s.metrics }
+      latest_metrics = LinkedData::Models::Metric.where.include(LinkedData::Models::Metric.goo_attrs_to_load(includes_param)).all
+                    .group_by { |x| x.id.split('/')[-4] }
+                    .transform_values { |metrics| metrics.max_by { |x| x.id.split('/')[-2].to_i } }
+      reply latest_metrics.values
     end
 
     #
@@ -84,33 +63,19 @@ class MetricsController < ApplicationController
   # Display metrics for ontology
   get "/ontologies/:ontology/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
-    ont, sub = get_ontology_and_submission
-    error 404, "Ontology #{params['ontology']} not found" unless ont
-    sub.bring(ontology: [:acronym], metrics: LinkedData::Models::Metric.goo_attrs_to_load(includes_param))
-    reply sub.metrics || {}
-    # ont_str = ""
-    # LinkedData::Models::Ontology.all.each  do |ont|
-    #   begin
-    #     sub = ont.latest_submission(status: :rdf)
-    #     sub.bring(ontology: [:acronym], metrics: LinkedData::Models::Metric.goo_attrs_to_load(includes_param))
-    #     if !sub.metrics
-    #       ont_str << "#{ont.acronym},"
-    #       puts ont_str
-    #     end
-    #   rescue Exception => e
-    #     puts "#{ont.acronym}: #{e.message}"
-    #   end
-    # end
-    # puts ont_str
-    # reply {}
+    ontology_metrics = LinkedData::Models::Metric
+                      .where(submission: {ontology: [acronym: params['ontology']]})
+                      .order_by(submission: {submissionId: :desc})
+                      .include(LinkedData::Models::Metric.goo_attrs_to_load(includes_param)).first
+    reply ontology_metrics || {}
   end
 
   get "/ontologies/:ontology/submissions/:ontology_submission_id/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
-    ont, sub = get_ontology_and_submission
-    error 404, "Ontology #{params['ontology']} not found" unless ont
-    sub.bring(ontology: [:acronym], metrics: LinkedData::Models::Metric.goo_attrs_to_load(includes_param))
-    reply sub.metrics || {}
+    ontology_submission_metrics = LinkedData::Models::Metric
+                      .where(submission: { submissionId: params['ontology_submission_id'].to_i, ontology: [acronym: params['ontology']] })
+                      .include(LinkedData::Models::Metric.goo_attrs_to_load(includes_param)).first
+    reply ontology_submission_metrics || {}
   end
 
 

--- a/controllers/metrics_controller.rb
+++ b/controllers/metrics_controller.rb
@@ -63,6 +63,8 @@ class MetricsController < ApplicationController
   # Display metrics for ontology
   get "/ontologies/:ontology/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
+    ont = Ontology.find(params['ontology']).first
+    error 404, "Ontology #{params['ontology']} not found" unless ont
     ontology_metrics = LinkedData::Models::Metric
                       .where(submission: {ontology: [acronym: params['ontology']]})
                       .order_by(submission: {submissionId: :desc})
@@ -72,6 +74,8 @@ class MetricsController < ApplicationController
 
   get "/ontologies/:ontology/submissions/:ontology_submission_id/metrics" do
     check_last_modified_collection(LinkedData::Models::Metric)
+    ont = Ontology.find(params['ontology']).first
+    error 404, "Ontology #{params['ontology']} not found" unless ont
     ontology_submission_metrics = LinkedData::Models::Metric
                       .where(submission: { submissionId: params['ontology_submission_id'].to_i, ontology: [acronym: params['ontology']] })
                       .include(LinkedData::Models::Metric.goo_attrs_to_load(includes_param)).first


### PR DESCRIPTION
### Context
The `/metrics` controller is too slow without the cache. This PR address this issue and optimize the routes.

### Diagnosis
- When we call `/ontologies/STY/metrics` and we check the logs of 4store (triple store) we see a lot of sparql queries are executed
![image](https://github.com/user-attachments/assets/a8c68542-1864-49a0-b404-bb70bcfb2b2a)

- The number of sparql queries executed (from Q2096 to Q2130) = 35 

- Check the full list of queries here: [List sparql queries (metrics)](https://www.notion.so/imadbourouche/Diagnosis-1b22388ee64580bba038fe31a5932cf8)
### Improvement
- With the new code we optimized a lot the number of sparql queries executed 
![image](https://github.com/user-attachments/assets/b377aedb-0db6-4eee-b40a-34674051f88a)

- The number of sparql queries executed (from Q2172 to Q2174) = 3


- Check the full list of queries after this change: [List sparql queries (metrics)](https://www.notion.so/imadbourouche/Diagnosis-1b22388ee64580bba038fe31a5932cf8)

|  criteria  | Before  | After  |
|-----------|-----------|-----------|
| Response time (for /metrics) | 42532 ms  (42 s)  | 14738 ms  (14 s) |
| Number of sparql queries to get metrics of one ontology | 35  queries | 3 queries  |
 
> the response time is tested in lovportal with ~700 ontology

### What's change
- We use now the `LinkedData::Models::Metric` to get the metrics without calling ontologies, submission and doing the logic to get metrics
- routes changed: `/metrics`, `/ontologies/:ontology/metrics`, `/ontologies/:ontology/submissions/:ontology_submission_id/metrics`

