### PR TITLE
Fix: use SemanticArtefactDistribution in /distributions route

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/ontoportal-lirmm/ontologies_linked_data.git
-  revision: 28d4083675acfc852c63198931e8ea5b3edfdfbc
+  revision: 766c6b0a5f4dd4bad4e11285b818f40195c72524
   branch: development
   specs:
     ontologies_linked_data (0.0.1)

--- a/controllers/mod/artefacts_controller.rb
+++ b/controllers/mod/artefacts_controller.rb
@@ -69,7 +69,7 @@ class ArtefactsController < ApplicationController
       get '/:artefactID/distributions' do
         artefact = find_artefact(params["artefactID"])
         check_last_modified_segment(LinkedData::Models::SemanticArtefactDistribution, [params["artefactID"]])
-        attributes, page, pagesize= settings_params(LinkedData::Models::SemanticArtefactCatalogRecord).first(3)
+        attributes, page, pagesize= settings_params(LinkedData::Models::SemanticArtefactDistribution).first(3)
         attributes = LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([]) if includes_param.first == :all
         distros = artefact.all_distributions(attributes, page, pagesize)
         reply distros


### PR DESCRIPTION
there is small typo in the `/distributions` route. It should be getting the attributes to display from SemanticArtefactDistribution to get attribute instead of SemanticArtefactCatalogRecord

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of distribution settings when viewing artefact distributions, ensuring correct pagination and attribute loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->