### PR TITLE
Hotfix: add virtuoso env variables to work

### DIFF
--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -119,7 +119,7 @@ provision() {
   )
   for cmd in "${commands[@]}"; do
     echo "[+] Run: $cmd"
-    docker_cron_cmd="docker compose -f docker-compose.yml -p ontoportal_docker run  --remove-orphans --rm --name cron-service  --service-ports ncbo_cron bash -c \"$cmd\" >/dev/null 2>&1" 
+    docker_cron_cmd="docker compose -f docker-compose.yml -p ontoportal_docker run  --remove-orphans --rm --name cron-service  --service-ports ncbo_cron bash -c \"$cmd\"" 
     if ! eval "$docker_cron_cmd"; then
         echo "Error: Failed to run provisioning .  $cmd"
         exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ x-app: &app
     GOO_BACKEND_NAME: virtuoso
     GOO_PORT: 8890
     GOO_HOST: virtuoso-ut
+    GOO_PATH_DATA: /sparql/
+    GOO_PATH_QUERY: /sparql/
+    GOO_PATH_UPDATE: /sparql/
     MGREP_HOST: mgrep-ut
     MGREP_PORT: 55555
     REPOSITORY_FOLDER: /srv/ontoportal/data/repository


### PR DESCRIPTION
### context
When using virtuoso in docker compose it wasn't working because it misses some env variables
```
    GOO_PATH_DATA: /sparql/
    GOO_PATH_QUERY: /sparql/
    GOO_PATH_UPDATE: /sparql/
```

this was affecting the test of bioportal_web_ui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new environment variables for backend service configuration to improve customization and integration.
- **Chores**
  - Updated provisioning commands to display all output and errors in the console for better visibility during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->