### PR TITLE
Fix: show federations portals api keys and fix for the API configuration interface

### DIFF
--- a/controllers/home_controller.rb
+++ b/controllers/home_controller.rb
@@ -16,7 +16,7 @@ class HomeController < ApplicationController
       catalog = catalog_class.all.first || create_catalog
       attributes_to_include =  includes_param[0] == :all ? catalog_class.attributes(:all) : catalog_class.goo_attrs_to_load(includes_param)
       catalog.bring(*attributes_to_include)
-      catalog.federated_portals = safe_parse(catalog.federated_portals) { |item| item.delete('apikey') } if catalog.loaded_attributes.include?(:federated_portals)
+      catalog.federated_portals = safe_parse(catalog.federated_portals) if catalog.loaded_attributes.include?(:federated_portals)
       catalog.fundedBy = safe_parse(catalog.fundedBy) if catalog.loaded_attributes.include?(:fundedBy) 
       reply catalog
     end
@@ -27,6 +27,7 @@ class HomeController < ApplicationController
       populate_from_params(catalog, params)
       if catalog.valid?
         catalog.save
+        @@root_last_modified = Time.now.httpdate
         status 200
         reply catalog
       else


### PR DESCRIPTION
- When we want to update the federations portal from the UI interface, we need to show the api keys so we can edit them
- update the last_modified when updating the catalog so that the browser and clients get the new updated data

needed for this: 
- https://github.com/ontoportal-lirmm/bioportal_web_ui/pull/929