### PR TITLE
Fix: align development branch with development docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 x-app: &app
-  image: agroportal/ontologies_api:master
+  image: agroportal/ontologies_api:development
   environment: &env
     # default bundle config resolves to /usr/local/bundle/config inside of the container
     # we are setting it to local app directory if we need to use 'bundle config local'


### PR DESCRIPTION
### Context
- This change is for running the test of bioportal_web_ui. 

- When running the test of bioportal_web_ui, it's using the ontoportal_docker to run the api, we change it so it uses the development branch for testing because it's the branch that has the latest features and changes 
https://github.com/ontoportal-lirmm/ontoportal_docker/blob/development/.env.sample#L3-L4
even with that the problem is still occurring because the development branch used the docker image `ontologies_api:master` which is not aligned with the code of the development branch.

- example of tests that are not passing when not using the development branch is agents:
https://github.com/ontoportal-lirmm/bioportal_web_ui/actions/runs/15276077527/job/43079030990#step:9:1593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker image for the x-app service to use the latest development version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->