### PR TITLE
fix: remove Rack::RewindableInput Middleware causing post request to not work

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -145,7 +145,7 @@ if $SENTRY_DSN
     config.send_default_pii = true
   end
 
-  use Rack::RewindableInput::Middleware
+  # use Rack::RewindableInput::Middleware
   use Sentry::Rack::CaptureExceptions
 end
 


### PR DESCRIPTION
the RewindableInput middleware is causing post request to not parse it's params from the body