### PR TITLE
feat: integrate Sidekiq for handling asynchronous jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rake'
 gem 'rexml' # Investigate why unicorn fails to start under ruby 3 without adding rexml gem to the Gemfile
 gem 'sinatra'
 gem 'rackup'
+gem 'sidekiq', '7.3.9'
 
 github 'sinatra/sinatra' do
   gem 'sinatra-contrib'
@@ -54,7 +55,7 @@ gem 'pandoc-ruby'
 gem 'ncbo_annotator', git: 'https://github.com/agroportal/ncbo_annotator.git', branch: 'development'
 gem 'ncbo_cron', git: 'https://github.com/agroportal/ncbo_cron.git', branch: 'development'
 gem 'ncbo_ontology_recommender', git: 'https://github.com/agroportal/ncbo_ontology_recommender.git', branch: 'development'
-gem 'ontologies_linked_data', github: 'agroportal/ontologies_linked_data', branch: 'development'
+gem 'ontologies_linked_data', github: 'agroportal/ontologies_linked_data', branch: 'feat/sidekiq-integration'
 gem 'goo', github: 'agroportal/goo', branch: 'development'
 gem 'sparql-client', github: 'agroportal/sparql-client', branch: 'development'
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rexml' # Investigate why unicorn fails to start under ruby 3 without adding
 gem 'sinatra'
 gem 'rackup'
 gem 'sidekiq', '7.3.9'
+gem 'sidekiq-cron', '2.3.0'
 
 github 'sinatra/sinatra' do
   gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/agroportal/ontologies_linked_data.git
-  revision: bc036b27e82e338fd926f1824a893ba3dff8b2ac
+  revision: 3cc753e437751b45ded1eb0ef1d26e5f95ae24b8
   branch: feat/sidekiq-integration
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/agroportal/ncbo_cron.git
-  revision: 2eb5cfd12e6e8fd9d3b0a6610d836a358cdfc409
+  revision: 1447bf247caca0858cf4d454ec44fec6f3a44b55
   branch: development
   specs:
     ncbo_cron (0.0.1)
@@ -57,8 +57,8 @@ GIT
 
 GIT
   remote: https://github.com/agroportal/ontologies_linked_data.git
-  revision: e34ef6d84858c7235a6a28be77aca4a528e84b32
-  branch: development
+  revision: 3c3ff6749e7332521de5f9e43a22d1c47050d485
+  branch: feat/sidekiq-integration
   specs:
     ontologies_linked_data (0.0.1)
       activesupport
@@ -128,7 +128,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -137,7 +137,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.9)
@@ -148,12 +148,12 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bcp47_spec (0.2.1)
-    bcrypt (3.1.21)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bcrypt_pbkdf (1.1.2-arm64-darwin)
     bcrypt_pbkdf (1.1.2-x86_64-darwin)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.0)
     builder (3.3.0)
     capistrano (3.20.0)
       airbrussh (>= 1.0.0)
@@ -229,10 +229,12 @@ GEM
     google-cloud-env (2.3.1)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
-    google-cloud-errors (1.5.0)
+    google-cloud-errors (1.6.0)
     google-logging-utils (0.2.0)
     google-protobuf (3.25.3)
+    google-protobuf (3.25.3-aarch64-linux)
     google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86-linux)
     google-protobuf (3.25.3-x86_64-darwin)
     google-protobuf (3.25.3-x86_64-linux)
     googleapis-common-protos (1.8.0)
@@ -252,7 +254,13 @@ GEM
     grpc (1.70.1)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
+    grpc (1.70.1-aarch64-linux)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
     grpc (1.70.1-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.70.1-x86-linux)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.70.1-x86_64-darwin)
@@ -272,7 +280,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.19.1)
+    json (2.19.3)
     json-canonicalization (0.4.0)
     json-ld (3.2.5)
       htmlentities (~> 4.3)
@@ -300,13 +308,11 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mcp (0.8.0)
-      json-schema (>= 4.1)
     method_source (1.1.0)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0303)
+    mime-types-data (3.2026.0317)
     mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-fail-fast (0.2.0)
@@ -344,7 +350,7 @@ GEM
       net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (7.3.0)
+    net-ssh (7.3.2)
     netrc (0.11.0)
     oj (3.16.16)
       bigdecimal (>= 3.0)
@@ -356,7 +362,7 @@ GEM
     pandoc-ruby (2.1.10)
     parallel (1.27.0)
     parseconfig (1.1.2)
-    parser (3.3.10.2)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pony (1.13.1)
@@ -409,7 +415,7 @@ GEM
       rexml (~> 3.2)
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.27.0)
+    redis-client (0.28.0)
       connection_pool
     redis-rack-cache (2.2.1)
       rack-cache (>= 1.10, < 2)
@@ -435,11 +441,10 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rubocop (1.85.1)
+    rubocop (1.86.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      mcp (~> 0.6)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
@@ -447,7 +452,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
@@ -460,6 +465,12 @@ GEM
     sentry-ruby (5.28.1)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     signet (0.21.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -510,15 +521,17 @@ GEM
     uri (1.1.1)
     uuid (2.3.9)
       macaddr (~> 1.0)
-    webmock (3.26.1)
+    webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin
   ruby
+  x86-linux
   x86_64-darwin
   x86_64-linux
 
@@ -575,6 +588,7 @@ DEPENDENCIES
   rubocop
   sentry-ruby (~> 5.24)
   shotgun!
+  sidekiq (= 7.3.9)
   simplecov
   simplecov-cobertura
   sinatra
@@ -586,4 +600,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.6.7
+   2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/agroportal/ontologies_linked_data.git
-  revision: 3c3ff6749e7332521de5f9e43a22d1c47050d485
+  revision: bc036b27e82e338fd926f1824a893ba3dff8b2ac
   branch: feat/sidekiq-integration
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,9 @@ GEM
     connection_pool (2.5.5)
     crack (0.4.5)
       rexml
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     dante (0.2.0)
     date (3.5.1)
     declarative (0.0.20)
@@ -207,6 +210,8 @@ GEM
       grpc (~> 1.66)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
     google-analytics-data (0.7.2)
       google-analytics-data-v1beta (>= 0.11, < 2.a)
       google-cloud-core (~> 1.6)
@@ -471,6 +476,11 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    sidekiq-cron (2.3.0)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
     signet (0.21.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -509,6 +519,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    unicode (0.4.4.5)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -589,6 +600,7 @@ DEPENDENCIES
   sentry-ruby (~> 5.24)
   shotgun!
   sidekiq (= 7.3.9)
+  sidekiq-cron (= 2.3.0)
   simplecov
   simplecov-cobertura
   sinatra

--- a/app.rb
+++ b/app.rb
@@ -29,6 +29,10 @@ require_relative 'lib/rack/param_translator'
 require_relative 'lib/rack/slice_detection'
 require_relative 'lib/rack/request_lang'
 
+# sidekiq requirements
+require 'sidekiq/web'
+require 'sidekiq'
+
 # Logging setup
 require_relative 'config/logging'
 

--- a/app.rb
+++ b/app.rb
@@ -31,8 +31,9 @@ require_relative 'lib/rack/request_lang'
 
 # sidekiq requirements
 require 'sidekiq'
+require 'sidekiq-cron'
 require 'sidekiq/web'
-
+require 'sidekiq/cron/web'
 # Logging setup
 require_relative 'config/logging'
 

--- a/app.rb
+++ b/app.rb
@@ -33,12 +33,7 @@ require_relative 'lib/rack/request_lang'
 require 'sidekiq/web'
 require 'sidekiq'
 
-# We need to require deterministic - that is why we have the sort.
-jobs = Dir.glob("jobs/**/*.rb").sort
 
-jobs.each do |job|
-  require_relative job
-end
 # Logging setup
 require_relative 'config/logging'
 

--- a/app.rb
+++ b/app.rb
@@ -30,9 +30,8 @@ require_relative 'lib/rack/slice_detection'
 require_relative 'lib/rack/request_lang'
 
 # sidekiq requirements
-require 'sidekiq/web'
 require 'sidekiq'
-
+require 'sidekiq/web'
 
 # Logging setup
 require_relative 'config/logging'

--- a/app.rb
+++ b/app.rb
@@ -33,6 +33,12 @@ require_relative 'lib/rack/request_lang'
 require 'sidekiq/web'
 require 'sidekiq'
 
+# We need to require deterministic - that is why we have the sort.
+jobs = Dir.glob("jobs/**/*.rb").sort
+
+jobs.each do |job|
+  require_relative job
+end
 # Logging setup
 require_relative 'config/logging'
 

--- a/bin/ontoportal
+++ b/bin/ontoportal
@@ -96,7 +96,9 @@ build_docker_run_cmd() {
   local ncbo_path="$5"
 
   local docker_run_cmd="docker compose --profile vo -p ontoportal_docker run --rm -it --name api-service"
+  local sidekiq_run_cmd="docker compose --profile vo -p ontoportal_docker run --rm -d --name sidekiq-service"
   local bash_cmd=""
+  local sidekiq_bash_cmd=""
 
   # Conditionally add bind mounts only if the paths are not empty
   for path_var in "linked_data_path:ontologies_linked_data" "goo_path:goo" "sparql_client_path:sparql-client" "ncbo_path:ncbo_cron" ; do
@@ -107,15 +109,30 @@ build_docker_run_cmd() {
       echo "[+] Run: bundle config local.$value ${!path}"
       container_path="/srv/ontoportal/$value"
       docker_run_cmd+=" -v $host_path:$container_path"
+      sidekiq_run_cmd+=" -v $host_path:$container_path"
       bash_cmd+="(git config --global --add safe.directory $container_path && bundle config local.$value $container_path) &&"
+      sidekiq_bash_cmd+="(git config --global --add safe.directory $container_path && bundle config local.$value $container_path) &&"
     else
       bash_cmd+=" (bundle config unset local.$value) &&"
+      sidekiq_bash_cmd+=" (bundle config unset local.$value) &&"
     fi
   done
 
+  # Build sidekiq command with same bundle setup
+  local sidekiq_custom_command="bundle exec sidekiq -C /srv/ontoportal/ontologies_api/config/sidekiq.yml -r /srv/ontoportal/ontologies_api/app.rb --env=development"
+  sidekiq_bash_cmd+=" (bundle check || bundle install || bundle update) && $sidekiq_custom_command"
+  sidekiq_run_cmd+=" sidekiq bash -c \"$sidekiq_bash_cmd\""
+
+  # Start sidekiq detached first
+  echo "[+] Starting Sidekiq in detached mode..."
+  echo "[+] Run docker command $sidekiq_run_cmd"
+  eval "$sidekiq_run_cmd"
+
+  # Build and run API command
   bash_cmd+=" (bundle check || bundle install || bundle update) && $custom_command"
   docker_run_cmd+=" --service-ports api bash -c \"$bash_cmd\""
 
+  echo "[+] Starting API server..."
   echo "[+] Run docker command $docker_run_cmd"
   eval "$docker_run_cmd"
 }

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,6 @@
 require './app.rb'
 run Sinatra::Application
+
+map '/sidekiq' do
+  run Sidekiq::Web
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -103,5 +103,5 @@ NcboCron.config do |config|
   config.redis_host = REDIS_PERSISTENT_HOST.to_s
   config.redis_port = REDIS_PORT.to_i
   config.graphs_counts_report_path = './test/ontologies_report.json'
-#  config.ontology_report_path = REPORT_PATH
+  config.ontology_report_path = './test/ontologies_report.json'
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,4 @@
+ontologies_report_job:
+  cron: "30 1 * * *"
+  class: "LinkedData::Jobs::OntologiesReportJob"
+  queue: default

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -2,3 +2,10 @@ ontologies_report_job:
   cron: "30 1 * * *"
   class: "LinkedData::Jobs::OntologiesReportJob"
   queue: default
+
+mapping_counts_job:
+  cron: "30 0 * * 6"
+  class: "Jobs::MappingCountsJob"
+  queue: default
+  args: 
+    current_user: "cron-admin"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -9,3 +9,8 @@ mapping_counts_job:
   queue: default
   args: 
     current_user: "cron-admin"
+
+dictionary_generation_job:
+  cron: "30 3 * * *"
+  class: "Jobs::DictionaryGenerationJob"
+  queue: default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,14 @@
+:concurrency: 5
+
+:queues:
+  - default
+  - mailers
+  - critical
+
+#:timeout: 25
+
+:verbose: true
+
+:logfile: ./log/sidekiq.log
+
+:pidfile: ./tmp/pids/sidekiq.pid

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 :queues:
   - default
   - mailers
-  - critical
+  - submissions
 
 #:timeout: 25
 

--- a/controllers/admin_controller.rb
+++ b/controllers/admin_controller.rb
@@ -70,6 +70,7 @@ class AdminController < ApplicationController
       check_last_modified(latest)
       latest.bring(*submission_include_params)
       SubmissionProcessJob.perform_async({
+        "username" => current_user ? current_user.username.to_s : nil,
         "submission_id" => latest.id.to_s,
         "actions" => actions.transform_keys(&:to_s)
       })

--- a/controllers/admin_controller.rb
+++ b/controllers/admin_controller.rb
@@ -41,7 +41,7 @@ class AdminController < ApplicationController
     end
 
     get "/ontologies/:acronym/log" do
-      ont_report = NcboCron::Models::OntologiesReport.new.ontologies_report(false)
+      ont_report = LinkedData::Jobs::OntologiesReportJob.ontologies_report(false)
       log_path = ont_report[:ontologies].has_key?(params["acronym"].to_sym) ? "#{LinkedData.settings.repository_folder}/#{ont_report[:ontologies][params["acronym"].to_sym][:logFilePath]}" : ''
       log_contents = ''
 
@@ -94,29 +94,27 @@ class AdminController < ApplicationController
 
     get "/ontologies_report" do
       suppress_error = params["suppress_error"].eql?('true') # default = false
-      reply NcboCron::Models::OntologiesReport.new.ontologies_report(suppress_error)
+      reply LinkedData::Jobs::OntologiesReportJob.ontologies_report(suppress_error)
     end
 
     post "/ontologies_report" do
       ontologies = ontologies_param_to_acronyms(params)
-      args = {name: "ontologies_report", message: "refreshing ontologies report"}
-      process_id = process_long_operation(900, args) do |args|
-        NcboCron::Models::OntologiesReport.new.refresh_report(ontologies)
-      end
+      process_id = LinkedData::Jobs::OntologiesReportJob.perform_async({ "acronyms" => ontologies })
+      redis.setex(process_id, 900, MultiJson.dump("processing"))
       reply(process_id: process_id)
     end
 
     get "/ontologies_report/:process_id" do
-      process_id = MultiJson.load(redis.get(params["process_id"]))
+      status = MultiJson.load(redis.get(params["process_id"]))
 
-      if process_id.nil?
+      if status.nil?
         error 404, "Process id #{params["process_id"]} does not exit"
       else
-        if process_id === "done"
-          reply NcboCron::Models::OntologiesReport.new.ontologies_report(false)
+        if status === "done"
+          reply LinkedData::Jobs::OntologiesReportJob.ontologies_report(false)
         else
           # either "processing" OR errors {errors: ["errorA", "errorB"]}
-          reply process_id
+          reply status
         end
       end
     end

--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -136,7 +136,7 @@ class OntologiesController < ApplicationController
       error 422, "You must provide an existing `acronym` to delete" if ont.nil?
       ont.delete
       # update ontologies report file, if exists
-      NcboCron::Models::OntologiesReport.new.delete_ontologies_from_report([params["acronym"]])
+      LinkedData::Jobs::OntologiesReportJob.delete_ontologies_from_report([params["acronym"]])
       halt 204
     end
 
@@ -232,7 +232,7 @@ class OntologiesController < ApplicationController
           latest_any = ont.latest_submission(status: :any)
 
           if latest_any
-            log_path = "#{LinkedData.settings.repository_folder}/#{NcboCron::Models::OntologiesReport.new.log_file(params["acronym"], latest_any.submissionId.to_s)}"
+            log_path = "#{LinkedData.settings.repository_folder}/#{LinkedData::Jobs::OntologiesReportJob.log_file(params["acronym"], latest_any.submissionId.to_s)}"
 
             if !log_path.empty? && File.file?(log_path)
               file = File.open(log_path, "rb")

--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -64,6 +64,7 @@ class OntologiesController < ApplicationController
       latest.bring(*OntologySubmission.goo_attrs_to_load(includes_param))
       error 404, "Ontology #{params["acronym"]} is not configured to be remotely pulled" unless latest.remote_pulled?
       SubmissionProcessJob.perform_async({
+        "username" => current_user ? current_user.username.to_s : nil,
         "submission_id" => latest.id.to_s,
         "actions" => actions.transform_keys(&:to_s)
       })
@@ -88,6 +89,7 @@ class OntologiesController < ApplicationController
         submission.save
         if (params.keys & REQUIRES_REPROCESS).length > 0 || request_has_file?
           SubmissionProcessJob.perform_async({
+            "username" => current_user ? current_user.username.to_s : nil,
             "submission_id" => submission.id.to_s,
             "actions" => { "all" => true }
           })

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -81,8 +81,10 @@ class OntologySubmissionsController < ApplicationController
       if submission.valid?
         submission.save
         if (params.keys & REQUIRES_REPROCESS).length > 0 || request_has_file?
-          cron = NcboCron::Models::OntologySubmissionParser.new
-          cron.queue_submission(submission, {all: true})
+          SubmissionProcessJob.perform_async({
+            "submission_id" => submission.id.to_s,
+            "actions" => { "all" => true }
+          })
         end
       else
         error 422, submission.errors

--- a/controllers/ontology_submissions_controller.rb
+++ b/controllers/ontology_submissions_controller.rb
@@ -82,6 +82,7 @@ class OntologySubmissionsController < ApplicationController
         submission.save
         if (params.keys & REQUIRES_REPROCESS).length > 0 || request_has_file?
           SubmissionProcessJob.perform_async({
+            "username" => current_user ? current_user.username.to_s : nil,
             "submission_id" => submission.id.to_s,
             "actions" => { "all" => true }
           })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     volumes:
       - app_api:/srv/ontoportal/ontologies_api
       - repository:/srv/ontoportal/data/repository
+      - reports:/srv/ontoportal/data/reports
     depends_on:
       redis-ut:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 x-app: &app
   image: agroportal/ontologies_api:development
-  environment: &env
+  environment:
     # default bundle config resolves to /usr/local/bundle/config inside of the container
     # we are setting it to local app directory if we need to use 'bundle config local'
-    BUNDLE_PATH: /srv/ontoportal/bundle
+
+    # BUNDLE_PATH: /srv/ontoportal/bundle
+    &env
     COVERAGE: 'true' # enable simplecov code coverage
     REDIS_HOST: redis-ut
     REDIS_PORT: 6379
@@ -27,13 +29,10 @@ x-app: &app
   tty: true
   command: /bin/bash
 
-
-
 services:
   api:
     <<: *app
-    env_file:
-      .env
+    env_file: .env
     environment:
       <<: *env
       BUNDLE_APP_CONFIG: /srv/ontoportal/ontologies_api/.bundle
@@ -53,15 +52,28 @@ services:
       - "9393:9393"
     volumes:
       # bundle volume for hosting gems installed by bundle; it speeds up gem install in local development
+      - bundle:/srv/ontoportal/bundle
       - app_api:/srv/ontoportal/ontologies_api
       - repository:/srv/ontoportal/data/repository
-      - bundle:/srv/ontoportal/bundle
+
+  sidekiq:
+    <<: *app
+    env_file: .env
+    environment:
+      <<: *env
+      BUNDLE_APP_CONFIG: /srv/ontoportal/ontologies_api/.bundle
+
+    volumes:
+      - app_api:/srv/ontoportal/ontologies_api
+      - repository:/srv/ontoportal/data/repository
+    depends_on:
+      redis-ut:
+        condition: service_healthy
 
   ncbo_cron:
     <<: *app
     image: agroportal/ncbo_cron:development
-    env_file:
-      .env
+    env_file: .env
     environment:
       <<: *env
       BUNDLE_APP_CONFIG: /srv/ontoportal/ncbo_cron/.bundle
@@ -83,7 +95,6 @@ services:
         condition: service_started
       virtuoso-ut:
         condition: service_started
-
 
   mgrep-ut:
     image: ontoportal/mgrep-ncbo:0.1
@@ -141,11 +152,7 @@ services:
       - agdata:/agraph/data
       #      - ./agraph/etc:/agraph/etc
     command: >
-      bash -c "/agraph/bin/agraph-control --config /agraph/etc/agraph.cfg start
-      ; agtool repos create ontoportal_test --supersede
-      ; agtool users add anonymous
-      ; agtool users grant anonymous root:ontoportal_test:rw
-      ; tail -f /agraph/data/agraph.log"
+      bash -c "/agraph/bin/agraph-control --config /agraph/etc/agraph.cfg start ; agtool repos create ontoportal_test --supersede ; agtool users add anonymous ; agtool users grant anonymous root:ontoportal_test:rw ; tail -f /agraph/data/agraph.log"    
     # healthcheck:
     #   test: ["CMD-SHELL", "curl -sf http://127.0.0.1:10035/repositories/ontoportal_test/status | grep -iqE '(^running|^lingering)' || exit 1"]
     #   start_period: 10s
@@ -191,6 +198,7 @@ services:
       - gb
 
 volumes:
+  bundle:
   app_api:
   app_cron:
   agdata:
@@ -201,4 +209,3 @@ volumes:
   mgrep:
   logs:
   history:
-  bundle:

--- a/helpers/application_helper.rb
+++ b/helpers/application_helper.rb
@@ -425,6 +425,22 @@ module Sinatra
         env["REMOTE_USER"] || LinkedData::Models::User.new
       end
 
+      def set_current_user(username)
+        return if username.nil? || username.to_s.strip.empty?
+
+        user = LinkedData::Models::User.find(username).first
+        return unless user
+
+        user.bring_remaining
+
+                Thread.current[:remote_user] = user
+      end
+
+      def clear_current_user
+        Thread.current[:current_user] = nil
+        Thread.current[:env] = nil
+      end
+
       def include_param_contains?(str)
         str = str.to_s unless str.is_a?(String)
         class_params_include = params["include_for_class"] && params["include_for_class"].include?(str.to_sym)

--- a/helpers/ontology_helper.rb
+++ b/helpers/ontology_helper.rb
@@ -46,8 +46,11 @@ module Sinatra
 
         if ont_submission.valid?
           ont_submission.save
-          cron = NcboCron::Models::OntologySubmissionParser.new
-          cron.queue_submission(ont_submission, {all: true, params: params})
+          SubmissionProcessJob.perform_async({
+            "submission_id" => ont_submission.id.to_s,
+            "actions" => { "all" => true },
+            "params" => ::JSON.parse(params.to_json)
+          })        
         else
           error 400, ont_submission.errors
         end

--- a/helpers/ontology_helper.rb
+++ b/helpers/ontology_helper.rb
@@ -46,7 +46,8 @@ module Sinatra
 
         if ont_submission.valid?
           ont_submission.save
-          SubmissionProcessJob.perform_async({
+          SubmissionProcessJob.new.perform({
+            "username" => current_user ? current_user.username.to_s : nil,
             "submission_id" => ont_submission.id.to_s,
             "actions" => { "all" => true },
             "params" => ::JSON.parse(params.to_json)

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,7 @@ end
 require_relative 'controllers/application_controller'
 require_dir('lib')
 require_dir('helpers')
+require_dir('jobs')
 require_dir('models')
 require_dir('controllers')
 

--- a/jobs/base.rb
+++ b/jobs/base.rb
@@ -1,0 +1,5 @@
+module Jobs
+  class Base < LinkedData::Jobs::Base
+    include Sinatra::Helpers::ApplicationHelper
+  end
+end

--- a/jobs/dictionary_generation_job.rb
+++ b/jobs/dictionary_generation_job.rb
@@ -1,0 +1,23 @@
+module Jobs
+  class DictionaryGenerationJob < Jobs::Base
+    def perform(ptions = {})
+      logger = Sidekiq.logger
+      
+      begin
+        logger.info("Starting DictionaryGenerationJob (mgrep dictionary generation)...")
+        annotator = Annotator::Models::NcboAnnotator.new
+        # Using the logger if the method supports it, otherwise it will just use default logging
+        if annotator.respond_to?(:generate_dictionary_file)
+          annotator.generate_dictionary_file
+        else
+          logger.error("Annotator::Models::NcboAnnotator does not respond to generate_dictionary_file")
+          raise "Method generate_dictionary_file not found on NcboAnnotator"
+        end
+        logger.info("Finished DictionaryGenerationJob successfully.")
+      rescue Exception => e
+        logger.error("Error in DictionaryGenerationJob: #{e.message}\n#{e.backtrace.join("\n")}")
+        raise e
+      end
+    end
+  end
+end

--- a/jobs/mapping_count_job.rb
+++ b/jobs/mapping_count_job.rb
@@ -1,0 +1,20 @@
+module Jobs
+  class MappingCountsJob < Jobs::Base
+    def perform(options = {})
+      acronyms = options["acronyms"] || []
+      logger = Sidekiq.logger
+  
+      username = options["current_user"]
+      set_current_user(username) if username
+  
+      begin
+        logger.info("Starting MappingCountsJob for #{acronyms.empty? ? 'all ontologies' : acronyms.join(', ')}...")
+        LinkedData::Mappings.create_mapping_counts(logger, acronyms)
+        logger.info("Finished MappingCountsJob successfully.")
+      rescue Exception => e
+        logger.error("Error in MappingCountsJob: #{e.message}\n#{e.backtrace.join("\n")}")
+        raise e
+      end
+    end
+  end
+end

--- a/jobs/submission_process_job.rb
+++ b/jobs/submission_process_job.rb
@@ -1,0 +1,146 @@
+require 'logger'
+
+class SubmissionProcessJob < LinkedData::Jobs::Base
+  sidekiq_options queue: 'submissions'
+
+  PROCESS_ACTIONS = {
+    process_rdf: true,
+    generate_labels: true,
+    extract_metadata: true,
+    index_all_data: true,
+    index_search: true,
+    index_properties: true,
+    run_metrics: true,
+    process_annotator: true,
+    diff: true,
+    remote_pull: false
+  }.freeze
+
+  def perform(options = {})
+    submission_id = options["submission_id"]
+    actions = normalize_actions(options["actions"] || { "all" => true })
+
+    logger = Sidekiq.logger
+    multi_logger = LinkedData::Utils::MultiLogger.new(loggers: logger)
+    t0 = Time.now
+
+    # Handle remote_pull action: pull the ontology and get a new submission
+    if actions[:remote_pull]
+      acronym = acronym_from_submission_id(submission_id)
+      new_submission = do_remote_pull(acronym, logger)
+      return unless new_submission
+
+      submission_id = new_submission.id.to_s
+      actions.delete(:remote_pull)
+    end
+
+    sub = LinkedData::Models::OntologySubmission.find(RDF::IRI.new(submission_id)).first
+
+    unless sub
+      multi_logger.error "Submission #{submission_id} is not in the system. Processing cancelled..."
+      return
+    end
+
+    sub.bring_remaining
+    sub.ontology.bring(:acronym)
+    FileUtils.mkdir_p(sub.data_folder) unless Dir.exist?(sub.data_folder)
+
+    log_path = sub.parsing_log_path
+    logger.info "Logging parsing output to #{log_path}"
+    file_logger = Logger.new(log_path)
+    multi_logger.add_logger(file_logger)
+    multi_logger.info "Starting to process #{submission_id}"
+
+    # Check to make sure the file has been downloaded
+    if sub.pullLocation && (!sub.uploadFilePath || !File.exist?(sub.uploadFilePath))
+      multi_logger.debug "Pull location found (#{sub.pullLocation}), but no file in the upload file path (#{sub.uploadFilePath}). Retrying download."
+      file, filename = sub.download_ontology_file
+      file_location = sub.class.copy_file_repository(sub.ontology.acronym, sub.submissionId, file, filename)
+      file_location = "../" + file_location if file_location.start_with?(".") # relative path fix
+      sub.uploadFilePath = File.expand_path(file_location, __FILE__)
+      sub.save
+      multi_logger.debug "Download complete"
+    end
+
+    sub.process_submission(multi_logger, actions)
+    parsed = sub.ready?(status: [:rdf, :rdf_labels])
+
+    if parsed
+      archive_old_submissions(multi_logger, sub) if actions[:process_rdf]
+      process_annotator(multi_logger, sub) if actions[:process_annotator]
+      multi_logger.debug "Completed processing of #{submission_id} in #{(Time.now - t0).to_f.round(2)}s"
+    else
+      multi_logger.error "Submission #{submission_id} parsing failed"
+    end
+
+    NcboCron::Models::OntologiesReport.new(multi_logger).refresh_report([sub.ontology.acronym])
+
+    Notifier.notify_submission_processed(sub)
+  end
+
+  private
+
+  # Normalize action flags from the options hash.
+  # If `all: true`, use the full set of default actions.
+  # Otherwise, filter to only recognized action keys.
+  def normalize_actions(raw_actions)
+    actions = raw_actions.transform_keys(&:to_sym)
+
+    if actions[:all]
+      PROCESS_ACTIONS.dup
+    else
+      actions.select { |k, _| PROCESS_ACTIONS.key?(k) }
+    end
+  end
+
+  def acronym_from_submission_id(submission_id)
+    submission_id.to_s.split("/")[-3]
+  end
+
+  def do_remote_pull(acronym, logger)
+    NcboCron::Helpers::OntologyHelper.do_ontology_pull(
+      acronym,
+      enable_pull_umls: false,
+      umls_download_url: '',
+      logger: logger,
+      add_to_queue: false
+    )
+  end
+
+  def archive_old_submissions(logger, sub)
+    logger.debug "Archiving submissions previous to #{sub.id.to_s}..."
+    submissions = LinkedData::Models::OntologySubmission
+                    .where(ontology: sub.ontology)
+                    .include(:submissionId)
+                    .include(:submissionStatus)
+                    .all
+
+    recent_submissions = submissions.sort { |a, b| b.submissionId <=> a.submissionId }[0..10]
+    options = { process_rdf: false, index_search: false, index_commit: false,
+                run_metrics: false, reasoning: false, archive: true }
+
+    recent_submissions.each do |old_sub|
+      next if old_sub.id.to_s == sub.id.to_s
+      next if sub.submissionId < old_sub.submissionId
+      old_sub.process_submission(logger, options) unless old_sub.archived?
+    end
+    logger.debug "Completed archiving submissions previous to #{sub.id.to_s}"
+  end
+
+  def process_annotator(logger, sub)
+    parsed = sub.ready?(status: [:rdf, :rdf_labels])
+
+    if parsed
+      begin
+        annotator = Annotator::Models::NcboAnnotator.new
+        annotator.create_term_cache_for_submission(logger, sub)
+        annotator.generate_dictionary_file() unless NcboCron.settings.enable_dictionary_generation_cron_job
+      rescue Exception => e
+        logger.error(e.message + "\n" + e.backtrace.join("\n\t"))
+        logger.flush() if logger.respond_to?(:flush)
+      end
+    else
+      logger.error "Annotator entries cannot be generated on the submission #{sub.id.to_s} because it has not been successfully parsed"
+    end
+  end
+end

--- a/jobs/submission_process_job.rb
+++ b/jobs/submission_process_job.rb
@@ -1,6 +1,8 @@
 require 'logger'
 
 class SubmissionProcessJob < LinkedData::Jobs::Base
+  include Sinatra::Helpers::ApplicationHelper
+  
   sidekiq_options queue: 'submissions'
 
   PROCESS_ACTIONS = {
@@ -17,6 +19,7 @@ class SubmissionProcessJob < LinkedData::Jobs::Base
   }.freeze
 
   def perform(options = {})
+    set_current_user(options["username"])
     submission_id = options["submission_id"]
     actions = normalize_actions(options["actions"] || { "all" => true })
 
@@ -74,8 +77,8 @@ class SubmissionProcessJob < LinkedData::Jobs::Base
     end
 
     NcboCron::Models::OntologiesReport.new(multi_logger).refresh_report([sub.ontology.acronym])
-
-    Notifier.notify_submission_processed(sub)
+  
+    clear_current_user
   end
 
   private

--- a/jobs/submission_process_job.rb
+++ b/jobs/submission_process_job.rb
@@ -76,7 +76,7 @@ class SubmissionProcessJob < LinkedData::Jobs::Base
       multi_logger.error "Submission #{submission_id} parsing failed"
     end
 
-    NcboCron::Models::OntologiesReport.new(multi_logger).refresh_report([sub.ontology.acronym])
+    LinkedData::Jobs::OntologiesReportJob.perform_async({ "acronyms" => [sub.ontology.acronym] })
   
     clear_current_user
   end


### PR DESCRIPTION
Add Sidekiq support and UI to the development Docker environment  

- Integrate Sidekiq workers into the Docker‑compose stack for local development.  
- Expose the Sidekiq Web UI at `/sidekiq` (protected by basic auth, with these default creds: `sidekq:sidekiq`).  
- Update Dockerfile and entrypoint to start Sidekiq based on the API Image.  
<img width="1754" height="798" alt="Screenshot 2026-03-31 at 11 12 19" src="https://github.com/user-attachments/assets/9134692f-aed2-435e-adf0-180fb4358f8b" />
