### PR TITLE
Clean up note reference when deleting a reply

### DIFF
--- a/controllers/replies_controller.rb
+++ b/controllers/replies_controller.rb
@@ -78,8 +78,35 @@ class RepliesController < ApplicationController
     # Delete a reply
     delete '/:replyid' do
       _reply = LinkedData::Models::Notes::Reply.find(params["replyid"]).first
-      _reply.delete
+      error 404, "Reply #{params["replyid"]} not found" if _reply.nil?
+      remove_reply(_reply)
       halt 204
+    end
+
+    # Detach the reply from any note that references it and recursively delete
+    # its child replies before deleting the reply itself, so that no dangling
+    # reference to the deleted reply is left behind.
+    def remove_reply(reply)
+      notes_referencing(reply).each do |note|
+        note.reply = note.reply.reject { |r| r.id == reply.id }
+        note.save
+      end
+
+      reply.bring(:children) unless reply.loaded_attributes.include?(:children)
+      reply.children.each { |child| remove_reply(child) }
+
+      reply.delete
+    end
+    
+    def notes_referencing(reply)
+      reply_predicate = LinkedData::Models::Note.attribute_uri(:reply)
+      Goo.sparql_query_client
+         .select(:id).distinct
+         .from(LinkedData::Models::Note.uri_type)
+         .where([:id, reply_predicate, reply.id])
+         .each_solution
+         .map { |sol| LinkedData::Models::Note.find(sol[:id]).include(LinkedData::Models::Note.attributes).first }
+         .compact
     end
   end
 end

--- a/test/controllers/test_replies_controller.rb
+++ b/test/controllers/test_replies_controller.rb
@@ -79,4 +79,51 @@ class TestRepliesController < TestCase
     assert last_response.status == 204
   end
 
+  def test_delete_reply_removes_note_reference
+    note = LinkedData::Models::Note.new({
+      creator: @@user,
+      subject: "Note for delete reference test",
+      body: "Body for delete reference test",
+      relatedOntology: [@@ontology]
+    })
+    note.save
+
+    reply = LinkedData::Models::Notes::Reply.new({
+      creator: @@user,
+      body: "Reply to be deleted"
+    })
+    reply.save
+
+    child = LinkedData::Models::Notes::Reply.new({
+      creator: @@user,
+      body: "Child of the deleted reply",
+      parent: reply
+    })
+    child.save
+
+    note.reply = (note.reply || []).dup.push(reply)
+    note.save
+
+    reply_id = reply.id
+    child_id = child.id
+
+    delete reply_id.to_s
+    assert_equal 204, last_response.status
+
+    # The reply and its child are gone
+    assert_nil LinkedData::Models::Notes::Reply.find(reply_id).first
+    assert_nil LinkedData::Models::Notes::Reply.find(child_id).first
+
+    # The parent note no longer references the deleted reply
+    note_after = LinkedData::Models::Note.find(note.id).include(:reply).first
+    refute_includes (note_after.reply || []).map { |r| r.id }, reply_id
+
+    note_after.delete
+  end
+
+  def test_delete_missing_reply_returns_404
+    delete "/replies/does-not-exist"
+    assert_equal 404, last_response.status
+  end
+
 end


### PR DESCRIPTION
## Problem

Deleting a reply (`DELETE /replies/:id`) only removed the reply's own triples. This left:
- the parent note still referencing the now-deleted reply in its `reply` list (dangling reference), and
- any nested child replies orphaned (their `parent` pointing at a deleted reply).

It also returned a 500 (`NoMethodError` on `nil.delete`) when the reply id didn't exist.

## Change

`DELETE /replies/:id` now:
- detaches the reply from every note that references it.
- recursively deletes child replies, and
- returns **404** instead of crashing when the reply doesn't exist.

## Note

`Note#save` fires `LinkedData::Utils::Notifications.new_note` (rescued), so detaching a reply triggers a "new note" notification, the same pre-existing quirk that already fires when a reply is *added*. Left as-is to keep this change focused; happy to suppress it on this path (delete just the `<note> reply <reply>` triple) in a follow-up if wanted.