### PR TITLE
Fix incorrect data.bioontology.org URL in 'ontology already exists' 409 error

### DIFF
--- a/controllers/ontologies_controller.rb
+++ b/controllers/ontologies_controller.rb
@@ -182,7 +182,7 @@ class OntologiesController < ApplicationController
         ont = instance_from_params(Ontology, params)
       else
         error_msg = <<-ERR
-        Ontology already exists, see #{ont.id}
+        Ontology already exists, see #{LinkedData::Models::Base.replace_url_id_to_prefix(ont.id)}
         To add a new submission, POST to: /ontologies/#{params['acronym']}/submission.
         To modify the resource, use PATCH.
         ERR


### PR DESCRIPTION
Related issue: https://github.com/ontoportal-astro/project-management/issues/45

## Problem

Creating an ontology with an acronym that already exists returns a `409` whose message exposes the **internal** id prefix (http://data.bioontology.org/) instead of the portal's public URL:

```json
{
  "errors": [
    "Ontology already exists, see http://data.bioontology.org/ontologies/AGROVOC\n        To add a new submission, POST to: /ontologies/AGROVOC/submission.\n        To modify the resource, use PATCH.\n"
  ],
  "status": 409
}
```

The `http://data.bioontology.org/...` URL is wrong for any non-BioPortal deployment (e.g. AgroPortal).

## Fix

Run the id through `LinkedData::Models::Base.replace_url_id_to_prefix(ont.id)`, which converts `id_url_prefix` → `rest_url_prefix`